### PR TITLE
Updated german translations

### DIFF
--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,28 +1,28 @@
 datatable:
     common:
-        are_you_sure: "Bist du sicher ?"
+        are_you_sure: "Bist du sicher?"
         you_need_to_select_at_least_one_element: "Sie müssen mindestens ein Element auswählen."
-        search: Zoeken
+        search: Suchen
         execute: "Ausführen"
         ok: "OK"
     datatable:
         searchPlaceholder: ""
-        emptyTable:     "Geen resultaten aanwezig in de tabel"
-        info:           "_START_ tot _END_ van _TOTAL_ resultaten"
-        infoEmpty:      "Geen resultaten om weer te geven"
-        infoFiltered:   " (gefilterd uit _MAX_ resultaten)"
+        emptyTable:     "Keine Daten in der Tabelle vorhanden"
+        info:           "_START_ bis _END_ von _TOTAL_ Einträgen"
+        infoEmpty:      "0 bis 0 von 0 Einträgen"
+        infoFiltered:   " (gefiltert von _MAX_ Einträgen)"
         infoPostFix:    ""
         infoThousands:  "."
-        lengthMenu:     "_MENU_ resultaten weergeven"
-        loadingRecords: "Een moment geduld aub - bezig met laden..."
-        processing:     "Bezig..."
-        search:         "Zoeken:"
-        zeroRecords:    "Geen resultaten gevonden"
+        lengthMenu:     "_MENU_ Einträge anzeigen"
+        loadingRecords: "Wird geladen..."
+        processing:     "Bitte warten..."
+        search:         "Suchen"
+        zeroRecords:    "Keine Einträge vorhanden."
         paginate:
-            first:    "Eerste"
-            last:     "Laatste"
-            next:     "Volgende"
-            previous: "Vorige"
+            first:    "Erste"
+            last:     "Letzte"
+            next:     "Nächste"
+            previous: "Vorherige"
         aria:
             sortAscending:  ": zu aktivieren, um Spalte aufsteigend zu sortieren"
             sortDescending: ": zu aktivieren, um Spalte absteigend sortieren"


### PR DESCRIPTION
The German translation is a bit German but most of it is Dutch.

I used the official datatables.net translations as a base. 
http://cdn.datatables.net/plug-ins/1.10.15/i18n/German.json