### PR TITLE
fix URL state when using base href

### DIFF
--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -88,10 +88,12 @@
                             var diff = data.filter(el => { return baseState.indexOf(el) === -1 && el.indexOf('time=') !== 0; });
                             switch (config.state) {
                                 case 'fragment':
-                                    history.replaceState(null, null, '#' + decodeURIComponent(diff.join('&')));
+                                    history.replaceState(null, null, window.location.origin + window.location.pathname + window.location.search
+                                        + '#' + decodeURIComponent(diff.join('&')));
                                     break;
                                 case 'query':
-                                    history.replaceState(null, null, '?' + decodeURIComponent(diff.join('&')));
+                                    history.replaceState(null, null, window.location.origin + window.location.pathname
+                                        + '?' + decodeURIComponent(diff.join('&') + window.location.hash));
                                     break;
                             }
                         }


### PR DESCRIPTION
should be safer than https://github.com/omines/datatables-bundle/pull/29

Using `window.location.hash = ...` and `window.location.search = ...` also work but that changing browser history
