### PR TITLE
Fix Symfony 4.2 deprecation for tree builder without a root node

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,8 +25,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('datatables');
+        $treeBuilder = new TreeBuilder('datatables');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('datatables');
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fix 4.2 deprecation for treebuilder without a root node.