### PR TITLE
Update the url used for ajax request on each init.

### DIFF
--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -13,6 +13,10 @@
      * Initializes the datatable dynamically.
      */
     $.fn.initDataTables = function(config, options) {
+        
+        //Update default used url, so it reflects the current location (useful on single side apps)	
+        $.fn.initDataTables.defaults.url = window.location.origin + window.location.pathname;
+        
         var root = this,
             config = $.extend({}, $.fn.initDataTables.defaults, config),
             state = ''


### PR DESCRIPTION
This is needed on single page applications, where pages are loaded via ajax and the url is changed via history api.

Without this change, on a single page application, each time initDataTables is called, the same data is loaded.