### PR TITLE
Add DataTable Events

### DIFF
--- a/docs/source/index.html.md
+++ b/docs/source/index.html.md
@@ -300,6 +300,28 @@ Note that implementing your own criteria overrides the default, meaning searchin
 longer work automatically. Add the `SearchCriteriaProvider` manually to combine the default behavior
 with your own implementation.
 
+### Events
+
+```php?start_inline=1
+$table->createAdapter(ORMAdapter::class, [
+    'entity' => Employee::class,
+    'query' => function (QueryBuilder $builder) {
+        $builder
+            ->select('e')
+            ->addSelect('c')
+            ->from(Employee::class, 'e')
+            ->leftJoin('e.company', 'c')
+        ;
+    },
+]);
+
+$table->addEventListener(ORMAdapterEvents::PRE_QUERY, function(ORMAdapterQueryEvent $event) {
+    $event->getQuery()->useResultCache(true)->useQueryCache(true);
+});
+```
+The `PRE_QUERY` event is dispatched after the QueryBuilder built the Query
+and before the iteration starts. It can be useful to configure the cache.
+
 ## Elastica
 
 ```php?start_inline=1

--- a/src/Adapter/Doctrine/Event/ORMAdapterQueryEvent.php
+++ b/src/Adapter/Doctrine/Event/ORMAdapterQueryEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Adapter\Doctrine\Event;
+
+use Doctrine\ORM\Query;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @author Maxime Pinot <contact@maximepinot.com>
+ */
+class ORMAdapterQueryEvent extends Event
+{
+    /** @var Query */
+    protected $query;
+
+    /**
+     * ORMAdapterQueryEvent constructor.
+     *
+     * @param Query $query
+     */
+    public function __construct(Query $query)
+    {
+        $this->query = $query;
+    }
+
+    /**
+     * @return Query
+     */
+    public function getQuery(): Query
+    {
+        return $this->query;
+    }
+}

--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -26,7 +26,6 @@ use Omines\DataTablesBundle\DataTableState;
 use Omines\DataTablesBundle\Exception\InvalidConfigurationException;
 use Omines\DataTablesBundle\Exception\MissingDependencyException;
 use Symfony\Bridge\Doctrine\RegistryInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -56,24 +55,18 @@ class ORMAdapter extends AbstractAdapter
     /** @var QueryBuilderProcessorInterface[] */
     protected $criteriaProcessors;
 
-    /** @var EventDispatcherInterface */
-    protected $eventDispatcher;
-
     /**
      * DoctrineAdapter constructor.
      *
-     * @param EventDispatcherInterface $eventDispatcher
      * @param RegistryInterface|null $registry
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher, RegistryInterface $registry = null)
+    public function __construct(RegistryInterface $registry = null)
     {
         if (null === $registry) {
             throw new MissingDependencyException('Install doctrine/doctrine-bundle to use the ORMAdapter');
         }
 
         parent::__construct();
-
-        $this->eventDispatcher = $eventDispatcher;
         $this->registry = $registry;
     }
 
@@ -207,7 +200,7 @@ class ORMAdapter extends AbstractAdapter
 
         $query = $builder->getQuery();
         $event = new ORMAdapterQueryEvent($query);
-        $this->eventDispatcher->dispatch(ORMAdapterEvents::PRE_QUERY, $event);
+        $state->getDataTable()->getEventDispatcher()->dispatch(ORMAdapterEvents::PRE_QUERY, $event);
 
         foreach ($query->iterate([], $this->hydrationMode) as $result) {
             yield $entity = array_values($result)[0];

--- a/src/Adapter/Doctrine/ORMAdapterEvents.php
+++ b/src/Adapter/Doctrine/ORMAdapterEvents.php
@@ -27,9 +27,5 @@ final class ORMAdapterEvents
      *
      * @Event("Omines\DataTablesBundle\Adapter\Doctrine\Event\ORMAdapterQueryEvent")
      */
-    const PRE_QUERY = 'omines_datatables.pre_query';
-
-    private function __construct()
-    {
-    }
+    const PRE_QUERY = 'omines_datatables.ormadapter.pre_query';
 }

--- a/src/Adapter/Doctrine/ORMAdapterEvents.php
+++ b/src/Adapter/Doctrine/ORMAdapterEvents.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Adapter\Doctrine;
+
+/**
+ * Available events.
+ *
+ * @author Maxime Pinot <contact@maximepinot.com>
+ */
+final class ORMAdapterEvents
+{
+    /**
+     * The PRE_QUERY event is dispatched after the QueryBuilder
+     * built the Query and before the iteration starts.
+     *
+     * It can be useful to configure the cache.
+     *
+     * @Event("Omines\DataTablesBundle\Adapter\Doctrine\Event\ORMAdapterQueryEvent")
+     */
+    const PRE_QUERY = 'omines_datatables.pre_query';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -19,6 +19,7 @@ use Omines\DataTablesBundle\DependencyInjection\Instantiator;
 use Omines\DataTablesBundle\Exception\InvalidArgumentException;
 use Omines\DataTablesBundle\Exception\InvalidConfigurationException;
 use Omines\DataTablesBundle\Exception\InvalidStateException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -65,6 +66,9 @@ class DataTable
     /** @var array<string, AbstractColumn> */
     protected $columnsByName = [];
 
+    /** @var EventDispatcherInterface */
+    protected $eventDispatcher;
+
     /** @var string */
     protected $method = Request::METHOD_POST;
 
@@ -104,11 +108,14 @@ class DataTable
     /**
      * DataTable constructor.
      *
+     * @param EventDispatcherInterface $eventDispatcher
      * @param array $options
      * @param Instantiator|null $instantiator
      */
-    public function __construct(array $options = [], Instantiator $instantiator = null)
+    public function __construct(EventDispatcherInterface $eventDispatcher, array $options = [], Instantiator $instantiator = null)
     {
+        $this->eventDispatcher = $eventDispatcher;
+
         $this->instantiator = $instantiator ?? new Instantiator();
 
         $resolver = new OptionsResolver();
@@ -134,6 +141,24 @@ class DataTable
 
         $this->columns[] = $column;
         $this->columnsByName[$name] = $column;
+
+        return $this;
+    }
+
+    /**
+     * Adds an event listener to an event on this DataTable.
+     *
+     * @param string   $eventName The name of the event to listen to
+     * @param callable $listener  The listener to execute
+     * @param int      $priority  The priority of the listener. Listeners
+     *                            with a higher priority are called before
+     *                            listeners with a lower priority.
+     *
+     * @return $this
+     */
+    public function addEventListener(string $eventName, callable $listener, int $priority = 0): self
+    {
+        $this->eventDispatcher->addListener($eventName, $listener, $priority);
 
         return $this;
     }

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -230,6 +230,14 @@ class DataTable
     }
 
     /**
+     * @return EventDispatcherInterface
+     */
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->eventDispatcher;
+    }
+
+    /**
      * @return bool
      */
     public function isLanguageFromCDN(): bool

--- a/src/DataTableFactory.php
+++ b/src/DataTableFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Omines\DataTablesBundle;
 
 use Omines\DataTablesBundle\DependencyInjection\Instantiator;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class DataTableFactory
@@ -29,17 +30,23 @@ class DataTableFactory
     /** @var array */
     protected $config;
 
+    /** @var EventDispatcherInterface */
+    protected $eventDispatcher;
+
     /**
      * DataTableFactory constructor.
      *
      * @param array $config
      * @param DataTableRendererInterface $renderer
+     * @param Instantiator $instantiator
+     * @param EventDispatcherInterface $eventDispatcher
      */
-    public function __construct(array $config, DataTableRendererInterface $renderer, Instantiator $instantiator)
+    public function __construct(array $config, DataTableRendererInterface $renderer, Instantiator $instantiator, EventDispatcherInterface $eventDispatcher)
     {
         $this->config = $config;
         $this->renderer = $renderer;
         $this->instantiator = $instantiator;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -50,7 +57,7 @@ class DataTableFactory
     {
         $config = $this->config;
 
-        return (new DataTable(array_merge($config['options'] ?? [], $options), $this->instantiator))
+        return (new DataTable($this->eventDispatcher, array_merge($config['options'] ?? [], $options), $this->instantiator))
             ->setRenderer($this->renderer)
             ->setMethod($config['method'] ?? Request::METHOD_POST)
             ->setPersistState($config['persist_state'] ?? 'fragment')

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -10,7 +10,6 @@
         <!-- Adapters -->
         <service id="Omines\DataTablesBundle\Adapter\ArrayAdapter" />
         <service id="Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter">
-            <argument type="service" id="event_dispatcher" />
             <argument type="service" id="doctrine" on-invalid="null" />
         </service>
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -10,6 +10,7 @@
         <!-- Adapters -->
         <service id="Omines\DataTablesBundle\Adapter\ArrayAdapter" />
         <service id="Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter">
+            <argument type="service" id="event_dispatcher" />
             <argument type="service" id="doctrine" on-invalid="null" />
         </service>
 
@@ -23,6 +24,7 @@
             <argument>%datatables.config%</argument>
             <argument type="service" id="datatables.renderer" />
             <argument type="service" id="Omines\DataTablesBundle\DependencyInjection\Instantiator" />
+            <argument type="service" id="event_dispatcher" />
         </service>
 
         <!-- Support services -->

--- a/tests/Fixtures/AppBundle/Controller/ORMAdapterEventsController.php
+++ b/tests/Fixtures/AppBundle/Controller/ORMAdapterEventsController.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\AppBundle\Controller;
+
+use Omines\DataTablesBundle\Adapter\Doctrine\Event\ORMAdapterQueryEvent;
+use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
+use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapterEvents;
+use Omines\DataTablesBundle\Column\TextColumn;
+use Omines\DataTablesBundle\Controller\DataTablesTrait;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Fixtures\AppBundle\Entity\Employee;
+
+/**
+ * @author Maxime Pinot <contact@maximepinot.com>
+ */
+class ORMAdapterEventsController extends AbstractController
+{
+    const PRE_QUERY_RESULT_CACHE_ID = 'datatable_result_cache';
+
+    use DataTablesTrait;
+
+    public function preQueryAction(Request $request): Response
+    {
+        $datatable = $this->createDataTable()
+            ->add('firstName', TextColumn::class)
+            ->add('lastName', TextColumn::class)
+            ->add('company', TextColumn::class, ['field' => 'company.name'])
+            ->createAdapter(ORMAdapter::class, [
+                'entity' => Employee::class,
+            ])
+            ->addEventListener(ORMAdapterEvents::PRE_QUERY, function (ORMAdapterQueryEvent $event) {
+                $event->getQuery()->useResultCache(true, 0, self::PRE_QUERY_RESULT_CACHE_ID);
+            });
+
+        return $datatable->handleRequest($request)->getResponse();
+    }
+}

--- a/tests/Fixtures/config.yml
+++ b/tests/Fixtures/config.yml
@@ -13,6 +13,12 @@ framework:
     test: ~
     profiler:
         collect: false
+    cache:
+        pools:
+            doctrine.result_cache_pool:
+                adapter: cache.app
+            doctrine.system_cache_pool:
+                adapter: cache.system
 
 doctrine:
     dbal:
@@ -23,6 +29,15 @@ doctrine:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
+        metadata_cache_driver:
+            type: service
+            id: doctrine.system_cache_provider
+        query_cache_driver:
+            type: service
+            id: doctrine.system_cache_provider
+        result_cache_driver:
+            type: service
+            id: doctrine.result_cache_provider
 
 twig:
     debug: '%kernel.debug%'

--- a/tests/Fixtures/routing.yml
+++ b/tests/Fixtures/routing.yml
@@ -25,3 +25,6 @@ grouped:
 employee.edit:
     path:       /employee/{id}
 
+orm_adapter_events.pre_query:
+    path: /orm-adapter-events/pre-query
+    controller: Tests\Fixtures\AppBundle\Controller\ORMAdapterEventsController::preQueryAction

--- a/tests/Fixtures/services.yml
+++ b/tests/Fixtures/services.yml
@@ -2,3 +2,14 @@ services:
     Tests\Fixtures\AppBundle\DataTable\Type\ServicePersonTableType:
         autowire: true
         autoconfigure: true
+
+    doctrine.result_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine.result_cache_pool'
+    doctrine.system_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine.system_cache_pool'

--- a/tests/Fixtures/services.yml
+++ b/tests/Fixtures/services.yml
@@ -8,6 +8,7 @@ services:
         public: false
         arguments:
             - '@doctrine.result_cache_pool'
+
     doctrine.system_cache_provider:
         class: Symfony\Component\Cache\DoctrineProvider
         public: false

--- a/tests/Functional/Adapter/Doctrine/ORMAdapterEventsTest.php
+++ b/tests/Functional/Adapter/Doctrine/ORMAdapterEventsTest.php
@@ -35,10 +35,10 @@ class ORMAdapterEventsTest extends WebTestCase
     public function testPreQueryEvent()
     {
         /** @var DoctrineProvider $doctrineProvider */
-        $doctrineProvider = self::$container->get('doctrine')->getManager()->getConfiguration()->getResultCacheImpl();
+        $doctrineProvider = self::$kernel->getContainer()->get('doctrine')->getManager()->getConfiguration()->getResultCacheImpl();
         $doctrineProvider->delete(ORMAdapterEventsController::PRE_QUERY_RESULT_CACHE_ID);
 
-        $this->client->xmlHttpRequest('POST', '/orm-adapter-events/pre-query', ['_dt' => 'dt', '_init' => true]);
+        $this->client->request('POST', '/orm-adapter-events/pre-query', ['_dt' => 'dt', '_init' => true]);
 
         static::assertTrue($doctrineProvider->contains(ORMAdapterEventsController::PRE_QUERY_RESULT_CACHE_ID));
     }

--- a/tests/Functional/Adapter/Doctrine/ORMAdapterEventsTest.php
+++ b/tests/Functional/Adapter/Doctrine/ORMAdapterEventsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Functional\Adapter\Doctrine;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\Cache\DoctrineProvider;
+use Tests\Fixtures\AppBundle\Controller\ORMAdapterEventsController;
+
+/**
+ * Tests events.
+ *
+ * @author Maxime Pinot <contact@maximepinot.com>
+ */
+class ORMAdapterEventsTest extends WebTestCase
+{
+    /** @var Client */
+    private $client;
+
+    protected function setUp()
+    {
+        $this->client = static::createClient();
+    }
+
+    public function testPreQueryEvent()
+    {
+        /** @var DoctrineProvider $doctrineProvider */
+        $doctrineProvider = self::$container->get('doctrine')->getManager()->getConfiguration()->getResultCacheImpl();
+        $doctrineProvider->delete(ORMAdapterEventsController::PRE_QUERY_RESULT_CACHE_ID);
+
+        $this->client->xmlHttpRequest('POST', '/orm-adapter-events/pre-query', ['_dt' => 'dt', '_init' => true]);
+
+        static::assertTrue($doctrineProvider->contains(ORMAdapterEventsController::PRE_QUERY_RESULT_CACHE_ID));
+    }
+
+    protected function tearDown()
+    {
+        $this->client = null;
+    }
+}

--- a/tests/Unit/Adapter/DoctrineTest.php
+++ b/tests/Unit/Adapter/DoctrineTest.php
@@ -21,6 +21,7 @@ use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -32,7 +33,7 @@ class DoctrineTest extends TestCase
 {
     public function testSearchCriteriaProvider()
     {
-        $table = new DataTable();
+        $table = new DataTable($this->createMock(EventDispatcher::class));
         $table
             ->add('firstName', TextColumn::class)
             ->add('lastName', TextColumn::class)
@@ -63,7 +64,7 @@ class DoctrineTest extends TestCase
      */
     public function testORMAdapterRequiresDependency()
     {
-        (new ORMAdapter());
+        (new ORMAdapter($this->createMock(EventDispatcher::class)));
     }
 
     /**
@@ -72,7 +73,9 @@ class DoctrineTest extends TestCase
      */
     public function testInvalidQueryProcessorThrows()
     {
-        (new ORMAdapter($this->createMock(RegistryInterface::class)))
+        $eventDispatcherMock = $this->createMock(EventDispatcher::class);
+        $registryMock = $this->createMock(RegistryInterface::class);
+        (new ORMAdapter($eventDispatcherMock, $registryMock))
             ->configure([
                 'entity' => 'bar',
                 'query' => ['foo'],
@@ -90,7 +93,7 @@ class DoctrineTest extends TestCase
         $column = new TextColumn();
         $column->initialize('foo', 0, ['field' => 'invalid'], $this->createMock(DataTable::class));
 
-        $mock = new class($this->createMock(RegistryInterface::class)) extends ORMAdapter {
+        $mock = new class($this->createMock(EventDispatcher::class), $this->createMock(RegistryInterface::class)) extends ORMAdapter {
             public function foo($query, $column)
             {
                 return $this->mapPropertyPath($query, $column);

--- a/tests/Unit/Adapter/DoctrineTest.php
+++ b/tests/Unit/Adapter/DoctrineTest.php
@@ -64,7 +64,7 @@ class DoctrineTest extends TestCase
      */
     public function testORMAdapterRequiresDependency()
     {
-        (new ORMAdapter($this->createMock(EventDispatcher::class)));
+        (new ORMAdapter());
     }
 
     /**
@@ -73,9 +73,7 @@ class DoctrineTest extends TestCase
      */
     public function testInvalidQueryProcessorThrows()
     {
-        $eventDispatcherMock = $this->createMock(EventDispatcher::class);
-        $registryMock = $this->createMock(RegistryInterface::class);
-        (new ORMAdapter($eventDispatcherMock, $registryMock))
+        (new ORMAdapter($this->createMock(RegistryInterface::class)))
             ->configure([
                 'entity' => 'bar',
                 'query' => ['foo'],
@@ -93,7 +91,7 @@ class DoctrineTest extends TestCase
         $column = new TextColumn();
         $column->initialize('foo', 0, ['field' => 'invalid'], $this->createMock(DataTable::class));
 
-        $mock = new class($this->createMock(EventDispatcher::class), $this->createMock(RegistryInterface::class)) extends ORMAdapter {
+        $mock = new class($this->createMock(RegistryInterface::class)) extends ORMAdapter {
             public function foo($query, $column)
             {
                 return $this->mapPropertyPath($query, $column);

--- a/tests/Unit/Adapter/ElasticaTest.php
+++ b/tests/Unit/Adapter/ElasticaTest.php
@@ -19,6 +19,7 @@ use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
 use Omines\DataTablesBundle\DataTableState;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -61,7 +62,7 @@ class ElasticaTest extends TestCase
         ;
 
         // Set up a dummy table
-        $table = (new DataTable())
+        $table = (new DataTable($this->createMock(EventDispatcher::class)))
             ->setName('foo')
             ->setMethod(Request::METHOD_GET)
             ->add('foo', TextColumn::class, ['field' => 'foo', 'globalSearchable' => true])

--- a/tests/Unit/AdapterTest.php
+++ b/tests/Unit/AdapterTest.php
@@ -15,6 +15,7 @@ namespace Tests\Unit;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * AdapterTest.
@@ -31,7 +32,7 @@ class AdapterTest extends TestCase
     {
         /** @var Registry $registryMock */
         $registryMock = $this->createMock(Registry::class);
-        $adapter = new ORMAdapter($registryMock);
+        $adapter = new ORMAdapter($this->createMock(EventDispatcher::class), $registryMock);
         $adapter->configure([
             'entity' => 'foobar',
         ]);

--- a/tests/Unit/AdapterTest.php
+++ b/tests/Unit/AdapterTest.php
@@ -15,7 +15,6 @@ namespace Tests\Unit;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * AdapterTest.
@@ -32,7 +31,7 @@ class AdapterTest extends TestCase
     {
         /** @var Registry $registryMock */
         $registryMock = $this->createMock(Registry::class);
-        $adapter = new ORMAdapter($this->createMock(EventDispatcher::class), $registryMock);
+        $adapter = new ORMAdapter($registryMock);
         $adapter->configure([
             'entity' => 'foobar',
         ]);

--- a/tests/Unit/ColumnTest.php
+++ b/tests/Unit/ColumnTest.php
@@ -20,6 +20,7 @@ use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\Column\TwigColumn;
 use Omines\DataTablesBundle\DataTable;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * ColumnTest.
@@ -34,7 +35,7 @@ class ColumnTest extends TestCase
         $column->initialize('test', 1, [
             'nullValue' => 'foo',
             'format' => 'd-m-Y',
-        ], (new DataTable())->setName('foo'));
+        ], (new DataTable($this->createMock(EventDispatcher::class)))->setName('foo'));
 
         $this->assertSame('03-04-2015', $column->transform('2015-04-03'));
         $this->assertSame('foo', $column->transform(null));
@@ -46,7 +47,7 @@ class ColumnTest extends TestCase
         $column->initialize('test', 1, [
             'data' => 'bar',
             'render' => 'foo%s',
-        ], (new DataTable())->setName('foo'));
+        ], (new DataTable($this->createMock(EventDispatcher::class)))->setName('foo'));
 
         $this->assertFalse($column->isRaw());
         $this->assertSame('foobar', $column->transform(null));
@@ -59,7 +60,7 @@ class ColumnTest extends TestCase
         $column->initialize('test', 1, [
              'trueValue' => 'yes',
              'nullValue' => '<em>null</em>',
-        ], new DataTable());
+        ], new DataTable($this->createMock(EventDispatcher::class)));
 
         $this->assertSame('yes', $column->transform(5));
         $this->assertSame('yes', $column->transform(true));
@@ -82,7 +83,7 @@ class ColumnTest extends TestCase
                 1 => 'bar',
                 2 => 'baz',
             ],
-        ], new DataTable());
+        ], new DataTable($this->createMock(EventDispatcher::class)));
 
         $this->assertSame('foo', $column->transform(0));
         $this->assertSame('bar', $column->transform(1));
@@ -93,7 +94,7 @@ class ColumnTest extends TestCase
     public function testNumberColumn()
     {
         $column = new NumberColumn();
-        $column->initialize('test', 1, [], new DataTable());
+        $column->initialize('test', 1, [], new DataTable($this->createMock(EventDispatcher::class)));
 
         $this->assertSame('5', $column->transform(5));
         $this->assertSame('1', $column->transform(true));
@@ -114,7 +115,7 @@ class ColumnTest extends TestCase
             'render' => function ($value) {
                 return mb_strtoupper($value);
             },
-        ], new DataTable());
+        ], new DataTable($this->createMock(EventDispatcher::class)));
 
         $this->assertFalse($column->isRaw());
         $this->assertSame('BAR', $column->transform(null));


### PR DESCRIPTION
Hi,

It can be useful to be able to modify the Query before the iteration starts. I personally need to do this so I can configure the Doctrine cache.

Here's how it works:

```php?start_inline=1
$table->createAdapter(ORMAdapter::class, [
    'entity' => Employee::class,
    'query' => function (QueryBuilder $builder) {
        $builder
            ->select('e')
            ->addSelect('c')
            ->from(Employee::class, 'e')
            ->leftJoin('e.company', 'c')
        ;
    },
]);

$table->addEventListener(ORMAdapterEvents::PRE_QUERY, function(ORMAdapterQueryEvent $event) {
    $event->getQuery()->useResultCache(true)->useQueryCache(true);
});
```