### PR TITLE
Use ManagerRegistry instead of RegistryInterface to fix deprecation.

### DIFF
--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -25,9 +25,9 @@ use Omines\DataTablesBundle\Column\AbstractColumn;
 use Omines\DataTablesBundle\DataTableState;
 use Omines\DataTablesBundle\Exception\InvalidConfigurationException;
 use Omines\DataTablesBundle\Exception\MissingDependencyException;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * ORMAdapter.
@@ -37,7 +37,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ORMAdapter extends AbstractAdapter
 {
-    /** @var RegistryInterface */
+    /** @var ManagerRegistry */
     private $registry;
 
     /** @var EntityManager */
@@ -58,9 +58,9 @@ class ORMAdapter extends AbstractAdapter
     /**
      * DoctrineAdapter constructor.
      *
-     * @param RegistryInterface|null $registry
+     * @param ManagerRegistry|null $registry
      */
-    public function __construct(RegistryInterface $registry = null)
+    public function __construct(ManagerRegistry $registry = null)
     {
         if (null === $registry) {
             throw new MissingDependencyException('Install doctrine/doctrine-bundle to use the ORMAdapter');


### PR DESCRIPTION
Since Symfony 4.4 Symfony\Bridge\Doctrine\RegistryInterface is deprecated, and removed in Symfony 5.0 (see issue #108 ).

Since RegistryInterface extends ManagerRegistry, there should be no BC break, even if the user has extended the ORMAdapter and extended the controller.