### PR TITLE
Symfony 3 is not supported, according to the readme.md

### DIFF
--- a/docs/source/index.html.md
+++ b/docs/source/index.html.md
@@ -13,7 +13,7 @@ search: true
 # Introduction
 
 This bundle provides convenient integration of the popular [DataTables](https://datatables.net/) jQuery library
-for realtime AJAX tables in your Symfony 3.3+ or 4.0+ application.
+for realtime AJAX tables in your 4.1+ application.
 
 Designed to be fully pluggable there are no limits to the data sources you can display through this library, nor
 are there any bounds on how they are displayed. In full *'batteries included but replaceable'* philosophy there are
@@ -25,7 +25,7 @@ Recommended way of installing this library is through [Composer](https://getcomp
 
 <code>composer require omines/datatables-bundle</code>
 
-Please ensure you are using Symfony 3.3 or later. If you are using Symfony Flex a recipe is included in the contrib
+Please ensure you are using Symfony 4.1 or later. If you are using Symfony Flex a recipe is included in the contrib
 repository, providing automatic installation and configuration.
 
 ```php?start_inline=true

--- a/docs/source/index.html.md
+++ b/docs/source/index.html.md
@@ -13,7 +13,7 @@ search: true
 # Introduction
 
 This bundle provides convenient integration of the popular [DataTables](https://datatables.net/) jQuery library
-for realtime AJAX tables in your 4.1+ application.
+for realtime AJAX tables in your Symfony 4.1+ application.
 
 Designed to be fully pluggable there are no limits to the data sources you can display through this library, nor
 are there any bounds on how they are displayed. In full *'batteries included but replaceable'* philosophy there are


### PR DESCRIPTION
Symfony 3 is not supported, according to the readme.md. 
This updates the documentation to reflect that only Symfony 4.1+ is supported by this bundle