### PR TITLE
Bugfix broken test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     fast_finish: true
     include:
      - php: 7.2
-       env: SYMFONY_VERSION=4.1.13
+       env: SYMFONY_VERSION=4.4
      - php: 7.2
        env: COMPOSER_FLAGS="--prefer-lowest"
      - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,10 @@
     "require": {
         "php": "^7.2",
         "symfony/contracts": "^1.1|^2.0",
-        "symfony/framework-bundle": "^4.1|^5.0",
-        "symfony/property-access": "^4.1|^5.0",
-        "symfony/translation": "^4.1|^5.0"
+        "symfony/framework-bundle": "^4.4|^5.0",
+        "symfony/property-access": "^4.4|^5.0",
+        "symfony/symfony": "^4.4",
+        "symfony/translation": "^4.4|^5.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
@@ -36,14 +37,14 @@
         "mongodb/mongodb": "^1.2",
         "phpunit/phpunit": "^7.5",
         "ruflin/elastica": "^6.0|^7.0",
-        "symfony/browser-kit": "^4.1|^5.0",
-        "symfony/css-selector": "^4.1|^5.0",
-        "symfony/dom-crawler": "^4.1|^5.0",
-        "symfony/phpunit-bridge": "^4.1|^5.0",
-        "symfony/templating": "^4.1|^5.0",
-        "symfony/twig-bundle": "^4.1|^5.0",
-        "symfony/var-dumper": "^4.1|^5.0",
-        "symfony/yaml": "^4.1|^5.0"
+        "symfony/browser-kit": "^4.4|^5.0",
+        "symfony/css-selector": "^4.4|^5.0",
+        "symfony/dom-crawler": "^4.4|^5.0",
+        "symfony/phpunit-bridge": "^4.4|^5.0",
+        "symfony/templating": "^4.4|^5.0",
+        "symfony/twig-bundle": "^4.4|^5.0",
+        "symfony/var-dumper": "^4.4|^5.0",
+        "symfony/yaml": "^4.4|^5.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "For integrated access to Doctrine object managers",

--- a/tests/Fixtures/config.yml
+++ b/tests/Fixtures/config.yml
@@ -42,6 +42,7 @@ doctrine:
 twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
+    exception_controller: null
 
 datatables:
     options:

--- a/tests/Functional/Adapter/Doctrine/ORMAdapterEventsTest.php
+++ b/tests/Functional/Adapter/Doctrine/ORMAdapterEventsTest.php
@@ -45,6 +45,7 @@ class ORMAdapterEventsTest extends WebTestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
         $this->client = null;
     }
 }

--- a/tests/Functional/Adapter/Doctrine/ORMAdapterEventsTest.php
+++ b/tests/Functional/Adapter/Doctrine/ORMAdapterEventsTest.php
@@ -42,10 +42,4 @@ class ORMAdapterEventsTest extends WebTestCase
 
         static::assertTrue($doctrineProvider->contains(ORMAdapterEventsController::PRE_QUERY_RESULT_CACHE_ID));
     }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->client = null;
-    }
 }


### PR DESCRIPTION
The parent tearDown method make the unset client and run all necessary.

With this, the continuous integration works again and the tests pass again