### PR TITLE
Use CallableResult for solving N+1 problem

### DIFF
--- a/src/Adapter/CallableResult.php
+++ b/src/Adapter/CallableResult.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Adapter;
+
+/**
+ * CallableResult.
+ *
+ * @author Niels Keurentjes <niels.keurentjes@omines.com>
+ */
+final class CallableResult
+{
+    /** @var callable */
+    private $callable;
+
+    /** @var array */
+    private $args;
+
+    /**
+     * CallableResult constructor.
+     *
+     * @param callable $callable
+     * @param array $args
+     */
+    public function __construct(callable $callable, array $args = [])
+    {
+        $this->callable = $callable;
+        $this->args = $args;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getCallable(): callable
+    {
+        return $this->callable;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+}

--- a/tests/Fixtures/AppBundle/Controller/PlainController.php
+++ b/tests/Fixtures/AppBundle/Controller/PlainController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Tests\Fixtures\AppBundle\Controller;
 
 use Doctrine\ORM\Query;
+use Omines\DataTablesBundle\Adapter\CallableResult;
 use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Omines\DataTablesBundle\Column\DateTimeColumn;
 use Omines\DataTablesBundle\Column\TextColumn;
@@ -48,6 +49,16 @@ class PlainController extends AbstractController
             ->add('buttons', TwigColumn::class, [
                 'template' => '@App/buttons.html.twig',
                 'data' => '<button>Click me</button>',
+            ])
+            ->add('callback', TextColumn::class, [
+                'render' => static function ($value, $context) {
+                    return new CallableResult(
+                        static function (array $row, int $id): string {
+                            return $row['DT_RowId'] === $id ? '_' . $id : '';
+                        },
+                        [$context['id']],
+                    );
+                },
             ])
             ->addOrderBy('lastName', DataTable::SORT_ASCENDING)
             ->addOrderBy('firstName', DataTable::SORT_DESCENDING)

--- a/tests/Fixtures/AppBundle/Controller/PlainController.php
+++ b/tests/Fixtures/AppBundle/Controller/PlainController.php
@@ -56,7 +56,7 @@ class PlainController extends AbstractController
                         static function (array $row, int $id): string {
                             return $row['DT_RowId'] === $id ? '_' . $id : '';
                         },
-                        [$context['id']],
+                        [$context['id']]
                     );
                 },
             ])

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -62,6 +62,7 @@ class FunctionalTest extends WebTestCase
         $sample = $json->data[5];
         $this->assertSame('FirstName94', $sample->firstName);
         $this->assertSame('LastName94', $sample->lastName);
+        $this->assertSame('_95', $sample->callback);
         $this->assertEmpty($sample->employedSince);
         $this->assertSame('FirstName94 &lt;img src=&quot;https://symfony.com/images/v5/logos/sf-positive.svg&quot;&gt; LastName94', $sample->fullName);
         $this->assertRegExp('#href="/employee/[0-9]+"#', $sample->buttons);


### PR DESCRIPTION
This pull request aims to add a possibility to postpone rendering of a cell until the end.
Using this, one can have a DataLoader that batches all calls that are needed to render a cell and make a single call instead of one per cell.