### PR TITLE
Fix deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-pdo_sqlite": "*",
         "doctrine/common": "^2.6",
         "doctrine/doctrine-bundle": "^2.0",
-        "doctrine/orm": "^2.5",
+        "doctrine/orm": "^2.6.3",
         "doctrine/persistence": "^1.3.4",
         "friendsofphp/php-cs-fixer": "^2.7",
         "mongodb/mongodb": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "symfony/css-selector": "^4.1|^5.0",
         "symfony/dom-crawler": "^4.1|^5.0",
         "symfony/phpunit-bridge": "^4.1|^5.0",
-        "symfony/templating": "^4.1|^5.0",
         "symfony/twig-bundle": "^4.1|^5.0",
         "symfony/var-dumper": "^4.1|^5.0",
         "symfony/yaml": "^4.1|^5.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/common": "^2.6",
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.5",
-        "doctrine/persistence": "^1.3",
+        "doctrine/persistence": "^1.3.4",
         "friendsofphp/php-cs-fixer": "^2.7",
         "mongodb/mongodb": "^1.2",
         "phpunit/phpunit": "^7.5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,4 +29,8 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="tests/phpunit-bootstrap.php">


### PR DESCRIPTION
Removed unused `symfony/templating`.
Set minimum version of `doctrine/persistence` to **1.3.4** (https://github.com/doctrine/persistence/pull/87).
`doctrine/orm` is forced to **2.6** by `doctrine/doctrine-bundle` so **2.6.3** makes sense as lowest version (https://github.com/doctrine/orm/pull/7307).