### PR TITLE
Make methods and properties of ORMAdapter protected instead of private

### DIFF
--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -262,7 +262,7 @@ class ORMAdapter extends AbstractAdapter
      * @param string $field
      * @return string
      */
-    private function mapFieldToPropertyPath($field, array $aliases = [])
+    protected function mapFieldToPropertyPath($field, array $aliases = [])
     {
         $parts = explode('.', $field);
         if (count($parts) < 2) {
@@ -317,7 +317,7 @@ class ORMAdapter extends AbstractAdapter
      * @param callable|QueryBuilderProcessorInterface $provider
      * @return QueryBuilderProcessorInterface
      */
-    private function normalizeProcessor($provider)
+    protected function normalizeProcessor($provider)
     {
         if ($provider instanceof QueryBuilderProcessorInterface) {
             return $provider;

--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -38,19 +38,19 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ORMAdapter extends AbstractAdapter
 {
     /** @var ManagerRegistry */
-    private $registry;
+    protected $registry;
 
     /** @var EntityManager */
-    private $manager;
+    protected $manager;
 
     /** @var \Doctrine\ORM\Mapping\ClassMetadata */
-    private $metadata;
+    protected $metadata;
 
     /** @var int */
-    private $hydrationMode;
+    protected $hydrationMode;
 
     /** @var QueryBuilderProcessorInterface[] */
-    private $queryBuilderProcessors;
+    protected $queryBuilderProcessors;
 
     /** @var QueryBuilderProcessorInterface[] */
     protected $criteriaProcessors;


### PR DESCRIPTION
This is needed in order to be able to extend ORMAdapter without duplicating the building of its properties.