### PR TITLE
Use trans() for proper locale fallback when using CDN languages

### DIFF
--- a/src/Resources/translations/DataTablesCDN.af.yml
+++ b/src/Resources/translations/DataTablesCDN.af.yml
@@ -1,0 +1,1 @@
+file: Afrikaans.json

--- a/src/Resources/translations/DataTablesCDN.ar.yml
+++ b/src/Resources/translations/DataTablesCDN.ar.yml
@@ -1,0 +1,1 @@
+file: Arabic.json

--- a/src/Resources/translations/DataTablesCDN.az.yml
+++ b/src/Resources/translations/DataTablesCDN.az.yml
@@ -1,0 +1,1 @@
+file: Azerbaijan.json

--- a/src/Resources/translations/DataTablesCDN.be.yml
+++ b/src/Resources/translations/DataTablesCDN.be.yml
@@ -1,0 +1,1 @@
+file: Belarusian.json

--- a/src/Resources/translations/DataTablesCDN.bg.yml
+++ b/src/Resources/translations/DataTablesCDN.bg.yml
@@ -1,0 +1,1 @@
+file: Bulgarian.json

--- a/src/Resources/translations/DataTablesCDN.bn.yml
+++ b/src/Resources/translations/DataTablesCDN.bn.yml
@@ -1,0 +1,1 @@
+file: Bangla.json

--- a/src/Resources/translations/DataTablesCDN.ca.yml
+++ b/src/Resources/translations/DataTablesCDN.ca.yml
@@ -1,0 +1,1 @@
+file: Catalan.json

--- a/src/Resources/translations/DataTablesCDN.cs.yml
+++ b/src/Resources/translations/DataTablesCDN.cs.yml
@@ -1,0 +1,1 @@
+file: Czech.json

--- a/src/Resources/translations/DataTablesCDN.cy.yml
+++ b/src/Resources/translations/DataTablesCDN.cy.yml
@@ -1,0 +1,1 @@
+file: Welsh.json

--- a/src/Resources/translations/DataTablesCDN.da.yml
+++ b/src/Resources/translations/DataTablesCDN.da.yml
@@ -1,0 +1,1 @@
+file: Danish.json

--- a/src/Resources/translations/DataTablesCDN.de.yml
+++ b/src/Resources/translations/DataTablesCDN.de.yml
@@ -1,0 +1,1 @@
+file: German.json

--- a/src/Resources/translations/DataTablesCDN.el.yml
+++ b/src/Resources/translations/DataTablesCDN.el.yml
@@ -1,0 +1,1 @@
+file: Greek.json

--- a/src/Resources/translations/DataTablesCDN.en.yml
+++ b/src/Resources/translations/DataTablesCDN.en.yml
@@ -1,0 +1,1 @@
+file: English.json

--- a/src/Resources/translations/DataTablesCDN.es.yml
+++ b/src/Resources/translations/DataTablesCDN.es.yml
@@ -1,0 +1,1 @@
+file: Spanish.json

--- a/src/Resources/translations/DataTablesCDN.et.yml
+++ b/src/Resources/translations/DataTablesCDN.et.yml
@@ -1,0 +1,1 @@
+file: Estonian.json

--- a/src/Resources/translations/DataTablesCDN.eu.yml
+++ b/src/Resources/translations/DataTablesCDN.eu.yml
@@ -1,0 +1,1 @@
+file: Basque.json

--- a/src/Resources/translations/DataTablesCDN.fa.yml
+++ b/src/Resources/translations/DataTablesCDN.fa.yml
@@ -1,0 +1,1 @@
+file: Persian.json

--- a/src/Resources/translations/DataTablesCDN.fi.yml
+++ b/src/Resources/translations/DataTablesCDN.fi.yml
@@ -1,0 +1,1 @@
+file: Finnish.json

--- a/src/Resources/translations/DataTablesCDN.fr.yml
+++ b/src/Resources/translations/DataTablesCDN.fr.yml
@@ -1,0 +1,1 @@
+file: French.json

--- a/src/Resources/translations/DataTablesCDN.ga.yml
+++ b/src/Resources/translations/DataTablesCDN.ga.yml
@@ -1,0 +1,1 @@
+file: Irish.json

--- a/src/Resources/translations/DataTablesCDN.gl.yml
+++ b/src/Resources/translations/DataTablesCDN.gl.yml
@@ -1,0 +1,1 @@
+file: Galician.json

--- a/src/Resources/translations/DataTablesCDN.gu.yml
+++ b/src/Resources/translations/DataTablesCDN.gu.yml
@@ -1,0 +1,1 @@
+file: Gujarati.json

--- a/src/Resources/translations/DataTablesCDN.he.yml
+++ b/src/Resources/translations/DataTablesCDN.he.yml
@@ -1,0 +1,1 @@
+file: Hebrew.json

--- a/src/Resources/translations/DataTablesCDN.hi.yml
+++ b/src/Resources/translations/DataTablesCDN.hi.yml
@@ -1,0 +1,1 @@
+file: Hindi.json

--- a/src/Resources/translations/DataTablesCDN.hr.yml
+++ b/src/Resources/translations/DataTablesCDN.hr.yml
@@ -1,0 +1,1 @@
+file: Croatian.json

--- a/src/Resources/translations/DataTablesCDN.hu.yml
+++ b/src/Resources/translations/DataTablesCDN.hu.yml
@@ -1,0 +1,1 @@
+file: Hungarian.json

--- a/src/Resources/translations/DataTablesCDN.hy.yml
+++ b/src/Resources/translations/DataTablesCDN.hy.yml
@@ -1,0 +1,1 @@
+file: Armenian.json

--- a/src/Resources/translations/DataTablesCDN.id.yml
+++ b/src/Resources/translations/DataTablesCDN.id.yml
@@ -1,0 +1,1 @@
+file: Indonesian.json

--- a/src/Resources/translations/DataTablesCDN.is.yml
+++ b/src/Resources/translations/DataTablesCDN.is.yml
@@ -1,0 +1,1 @@
+file: Icelandic.json

--- a/src/Resources/translations/DataTablesCDN.it.yml
+++ b/src/Resources/translations/DataTablesCDN.it.yml
@@ -1,0 +1,1 @@
+file: Italian.json

--- a/src/Resources/translations/DataTablesCDN.ja.yml
+++ b/src/Resources/translations/DataTablesCDN.ja.yml
@@ -1,0 +1,1 @@
+file: Japanese.json

--- a/src/Resources/translations/DataTablesCDN.ka.yml
+++ b/src/Resources/translations/DataTablesCDN.ka.yml
@@ -1,0 +1,1 @@
+file: Georgian.json

--- a/src/Resources/translations/DataTablesCDN.ko.yml
+++ b/src/Resources/translations/DataTablesCDN.ko.yml
@@ -1,0 +1,1 @@
+file: Korean.json

--- a/src/Resources/translations/DataTablesCDN.lt.yml
+++ b/src/Resources/translations/DataTablesCDN.lt.yml
@@ -1,0 +1,1 @@
+file: Lithuanian.json

--- a/src/Resources/translations/DataTablesCDN.lv.yml
+++ b/src/Resources/translations/DataTablesCDN.lv.yml
@@ -1,0 +1,1 @@
+file: Latvian.json

--- a/src/Resources/translations/DataTablesCDN.mk.yml
+++ b/src/Resources/translations/DataTablesCDN.mk.yml
@@ -1,0 +1,1 @@
+file: Macedonian.json

--- a/src/Resources/translations/DataTablesCDN.mn.yml
+++ b/src/Resources/translations/DataTablesCDN.mn.yml
@@ -1,0 +1,1 @@
+file: Mongolian.json

--- a/src/Resources/translations/DataTablesCDN.ms.yml
+++ b/src/Resources/translations/DataTablesCDN.ms.yml
@@ -1,0 +1,1 @@
+file: Malay.json

--- a/src/Resources/translations/DataTablesCDN.nb.yml
+++ b/src/Resources/translations/DataTablesCDN.nb.yml
@@ -1,0 +1,1 @@
+file: Norwegian.json

--- a/src/Resources/translations/DataTablesCDN.ne.yml
+++ b/src/Resources/translations/DataTablesCDN.ne.yml
@@ -1,0 +1,1 @@
+file: Nepali.json

--- a/src/Resources/translations/DataTablesCDN.nl.yml
+++ b/src/Resources/translations/DataTablesCDN.nl.yml
@@ -1,0 +1,1 @@
+file: Dutch.json

--- a/src/Resources/translations/DataTablesCDN.nn.yml
+++ b/src/Resources/translations/DataTablesCDN.nn.yml
@@ -1,0 +1,1 @@
+file: Norwegian.json

--- a/src/Resources/translations/DataTablesCDN.pl.yml
+++ b/src/Resources/translations/DataTablesCDN.pl.yml
@@ -1,0 +1,1 @@
+file: Polish.json

--- a/src/Resources/translations/DataTablesCDN.ps.yml
+++ b/src/Resources/translations/DataTablesCDN.ps.yml
@@ -1,0 +1,1 @@
+file: Pashto.json

--- a/src/Resources/translations/DataTablesCDN.pt.yml
+++ b/src/Resources/translations/DataTablesCDN.pt.yml
@@ -1,0 +1,1 @@
+file: Portuguese.json

--- a/src/Resources/translations/DataTablesCDN.ro.yml
+++ b/src/Resources/translations/DataTablesCDN.ro.yml
@@ -1,0 +1,1 @@
+file: Romanian.json

--- a/src/Resources/translations/DataTablesCDN.ru.yml
+++ b/src/Resources/translations/DataTablesCDN.ru.yml
@@ -1,0 +1,1 @@
+file: Russian.json

--- a/src/Resources/translations/DataTablesCDN.si.yml
+++ b/src/Resources/translations/DataTablesCDN.si.yml
@@ -1,0 +1,1 @@
+file: Sinhala.json

--- a/src/Resources/translations/DataTablesCDN.sk.yml
+++ b/src/Resources/translations/DataTablesCDN.sk.yml
@@ -1,0 +1,1 @@
+file: Slovak.json

--- a/src/Resources/translations/DataTablesCDN.sl.yml
+++ b/src/Resources/translations/DataTablesCDN.sl.yml
@@ -1,0 +1,1 @@
+file: Slovenian.json

--- a/src/Resources/translations/DataTablesCDN.sq.yml
+++ b/src/Resources/translations/DataTablesCDN.sq.yml
@@ -1,0 +1,1 @@
+file: Albanian.json

--- a/src/Resources/translations/DataTablesCDN.sr.yml
+++ b/src/Resources/translations/DataTablesCDN.sr.yml
@@ -1,0 +1,1 @@
+file: Serbian.json

--- a/src/Resources/translations/DataTablesCDN.sv.yml
+++ b/src/Resources/translations/DataTablesCDN.sv.yml
@@ -1,0 +1,1 @@
+file: Swedish.json

--- a/src/Resources/translations/DataTablesCDN.sw.yml
+++ b/src/Resources/translations/DataTablesCDN.sw.yml
@@ -1,0 +1,1 @@
+file: Swahili.json

--- a/src/Resources/translations/DataTablesCDN.ta.yml
+++ b/src/Resources/translations/DataTablesCDN.ta.yml
@@ -1,0 +1,1 @@
+file: Tamil.json

--- a/src/Resources/translations/DataTablesCDN.te.yml
+++ b/src/Resources/translations/DataTablesCDN.te.yml
@@ -1,0 +1,1 @@
+file: Telugu.json

--- a/src/Resources/translations/DataTablesCDN.th.yml
+++ b/src/Resources/translations/DataTablesCDN.th.yml
@@ -1,0 +1,1 @@
+file: Thai.json

--- a/src/Resources/translations/DataTablesCDN.tr.yml
+++ b/src/Resources/translations/DataTablesCDN.tr.yml
@@ -1,0 +1,1 @@
+file: Turkish.json

--- a/src/Resources/translations/DataTablesCDN.uk.yml
+++ b/src/Resources/translations/DataTablesCDN.uk.yml
@@ -1,0 +1,1 @@
+file: Ukranian.json

--- a/src/Resources/translations/DataTablesCDN.ur.yml
+++ b/src/Resources/translations/DataTablesCDN.ur.yml
@@ -1,0 +1,1 @@
+file: Urdu.json

--- a/src/Resources/translations/DataTablesCDN.uz.yml
+++ b/src/Resources/translations/DataTablesCDN.uz.yml
@@ -1,0 +1,1 @@
+file: Uzbek.json

--- a/src/Resources/translations/DataTablesCDN.vi.yml
+++ b/src/Resources/translations/DataTablesCDN.vi.yml
@@ -1,0 +1,1 @@
+file: Vietnamese.json

--- a/src/Resources/translations/DataTablesCDN.zh.yml
+++ b/src/Resources/translations/DataTablesCDN.zh.yml
@@ -1,0 +1,1 @@
+file: Chinese.json

--- a/src/Twig/DataTablesExtension.php
+++ b/src/Twig/DataTablesExtension.php
@@ -52,36 +52,35 @@ class DataTablesExtension extends \Twig\Extension\AbstractExtension
      */
     private function getLanguageSettings(DataTable $dataTable)
     {
-        $locale = $this->translator->getLocale();
-        if ($dataTable->isLanguageFromCDN() && array_key_exists($locale, self::LANGUAGES_IN_CDN)) {
-            return ['url' => '//cdn.datatables.net/plug-ins/1.10.15/i18n/' . self::LANGUAGES_IN_CDN[$locale]];
-        } else {
-            $domain = $dataTable->getTranslationDomain();
-
-            return [
-                'processing' => $this->translator->trans('datatable.datatable.processing', [], $domain),
-                'search' => $this->translator->trans('datatable.datatable.search', [], $domain),
-                'lengthMenu' => $this->translator->trans('datatable.datatable.lengthMenu', [], $domain),
-                'info' => $this->translator->trans('datatable.datatable.info', [], $domain),
-                'infoEmpty' => $this->translator->trans('datatable.datatable.infoEmpty', [], $domain),
-                'infoFiltered' => $this->translator->trans('datatable.datatable.infoFiltered', [], $domain),
-                'infoPostFix' => $this->translator->trans('datatable.datatable.infoPostFix', [], $domain),
-                'loadingRecords' => $this->translator->trans('datatable.datatable.loadingRecords', [], $domain),
-                'zeroRecords' => $this->translator->trans('datatable.datatable.zeroRecords', [], $domain),
-                'emptyTable' => $this->translator->trans('datatable.datatable.emptyTable', [], $domain),
-                'searchPlaceholder' => $this->translator->trans('datatable.datatable.searchPlaceholder', [], $domain),
-                'paginate' => [
-                    'first' => $this->translator->trans('datatable.datatable.paginate.first', [], $domain),
-                    'previous' => $this->translator->trans('datatable.datatable.paginate.previous', [], $domain),
-                    'next' => $this->translator->trans('datatable.datatable.paginate.next', [], $domain),
-                    'last' => $this->translator->trans('datatable.datatable.paginate.last', [], $domain),
-                ],
-                'aria' => [
-                    'sortAscending' => $this->translator->trans('datatable.datatable.aria.sortAscending', [], $domain),
-                    'sortDescending' => $this->translator->trans('datatable.datatable.aria.sortDescending', [], $domain),
-                ],
-            ];
+        if ($dataTable->isLanguageFromCDN() && ($cdnFile = $this->getCDNLanguageFile()) !== null) {
+            return ['url' => '//cdn.datatables.net/plug-ins/1.10.15/i18n/' . $cdnFile];
         }
+
+        $domain = $dataTable->getTranslationDomain();
+
+        return [
+            'processing' => $this->translator->trans('datatable.datatable.processing', [], $domain),
+            'search' => $this->translator->trans('datatable.datatable.search', [], $domain),
+            'lengthMenu' => $this->translator->trans('datatable.datatable.lengthMenu', [], $domain),
+            'info' => $this->translator->trans('datatable.datatable.info', [], $domain),
+            'infoEmpty' => $this->translator->trans('datatable.datatable.infoEmpty', [], $domain),
+            'infoFiltered' => $this->translator->trans('datatable.datatable.infoFiltered', [], $domain),
+            'infoPostFix' => $this->translator->trans('datatable.datatable.infoPostFix', [], $domain),
+            'loadingRecords' => $this->translator->trans('datatable.datatable.loadingRecords', [], $domain),
+            'zeroRecords' => $this->translator->trans('datatable.datatable.zeroRecords', [], $domain),
+            'emptyTable' => $this->translator->trans('datatable.datatable.emptyTable', [], $domain),
+            'searchPlaceholder' => $this->translator->trans('datatable.datatable.searchPlaceholder', [], $domain),
+            'paginate' => [
+                'first' => $this->translator->trans('datatable.datatable.paginate.first', [], $domain),
+                'previous' => $this->translator->trans('datatable.datatable.paginate.previous', [], $domain),
+                'next' => $this->translator->trans('datatable.datatable.paginate.next', [], $domain),
+                'last' => $this->translator->trans('datatable.datatable.paginate.last', [], $domain),
+            ],
+            'aria' => [
+                'sortAscending' => $this->translator->trans('datatable.datatable.aria.sortAscending', [], $domain),
+                'sortDescending' => $this->translator->trans('datatable.datatable.aria.sortDescending', [], $domain),
+            ],
+        ];
     }
 
     /**
@@ -94,69 +93,15 @@ class DataTablesExtension extends \Twig\Extension\AbstractExtension
         return 'DataTablesBundle';
     }
 
-    const LANGUAGES_IN_CDN = [
-        'af' => 'Afrikaans.json',
-        'ar' => 'Arabic.json',
-        'az' => 'Azerbaijan.json',
-        'be' => 'Belarusian.json',
-        'bg' => 'Bulgarian.json',
-        'bn' => 'Bangla.json',
-        'ca' => 'Catalan.json',
-        'cs' => 'Czech.json',
-        'cy' => 'Welsh.json',
-        'da' => 'Danish.json',
-        'de' => 'German.json',
-        'el' => 'Greek.json',
-        'en' => 'English.json',
-        'es' => 'Spanish.json',
-        'et' => 'Estonian.json',
-        'eu' => 'Basque.json',
-        'fa' => 'Persian.json',
-        'fi' => 'Finnish.json',
-        'fr' => 'French.json',
-        'ga' => 'Irish.json',
-        'gl' => 'Galician.json',
-        'gu' => 'Gujarati.json',
-        'he' => 'Hebrew.json',
-        'hi' => 'Hindi.json',
-        'hr' => 'Croatian.json',
-        'hu' => 'Hungarian.json',
-        'hy' => 'Armenian.json',
-        'id' => 'Indonesian.json',
-        'is' => 'Icelandic.json',
-        'it' => 'Italian.json',
-        'ja' => 'Japanese.json',
-        'ka' => 'Georgian.json',
-        'ko' => 'Korean.json',
-        'lt' => 'Lithuanian.json',
-        'lv' => 'Latvian.json',
-        'mk' => 'Macedonian.json',
-        'mn' => 'Mongolian.json',
-        'ms' => 'Malay.json',
-        'nb' => 'Norwegian.json',
-        'ne' => 'Nepali.json',
-        'nl' => 'Dutch.json',
-        'nn' => 'Norwegian.json',
-        'pl' => 'Polish.json',
-        'ps' => 'Pashto.json',
-        'pt' => 'Portuguese.json',
-        'ro' => 'Romanian.json',
-        'ru' => 'Russian.json',
-        'si' => 'Sinhala.json',
-        'sk' => 'Slovak.json',
-        'sl' => 'Slovenian.json',
-        'sq' => 'Albanian.json',
-        'sr' => 'Serbian.json',
-        'sv' => 'Swedish.json',
-        'sw' => 'Swahili.json',
-        'ta' => 'Tamil.json',
-        'te' => 'Telugu.json',
-        'th' => 'Thai.json',
-        'tr' => 'Turkish.json',
-        'uk' => 'Ukranian.json',
-        'ur' => 'Urdu.json',
-        'uz' => 'Uzbek.json',
-        'vi' => 'Vietnamese.json',
-        'zh' => 'Chinese.json',
-    ];
+    private function getCDNLanguageFile()
+    {
+        $file = $this->translator->trans('file', [], 'DataTablesCDN');
+
+        // CDN language file does not exists
+        if ($file === 'file') {
+            return null;
+        }
+
+        return $file;
+    }
 }

--- a/tests/Fixtures/AppBundle/Controller/TranslationController.php
+++ b/tests/Fixtures/AppBundle/Controller/TranslationController.php
@@ -17,14 +17,18 @@ use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTableFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * TranslationController.
  */
 class TranslationController extends AbstractController
 {
-    public function tableAction(Request $request, DataTableFactory $dataTableFactory)
+    public function tableAction(Request $request, DataTableFactory $dataTableFactory, TranslatorInterface $translator)
     {
+        // override default "en" fallback locale
+        $translator->setFallbackLocales([$request->getLocale()]);
+
         $datatable = $dataTableFactory->create();
         $datatable
             ->setName($request->query->has('cdn') ? 'CDN' : 'noCDN')

--- a/tests/Fixtures/AppBundle/Controller/TranslationController.php
+++ b/tests/Fixtures/AppBundle/Controller/TranslationController.php
@@ -27,9 +27,9 @@ class TranslationController extends AbstractController
     {
         $datatable = $dataTableFactory->create();
         $datatable
-            ->setName('noCDN')
+            ->setName($request->query->has('cdn') ? 'CDN' : 'noCDN')
             ->setMethod(Request::METHOD_GET)
-            ->setLanguageFromCDN(false)
+            ->setLanguageFromCDN($request->query->has('cdn'))
             ->add('col3', TextColumn::class, ['label' => 'foo', 'field' => 'bar'])
             ->add('col4', TextColumn::class, ['label' => 'bar', 'field' => 'foo'])
             ->createAdapter(ArrayAdapter::class)

--- a/tests/Fixtures/AppBundle/Resources/views/table.html.twig
+++ b/tests/Fixtures/AppBundle/Resources/views/table.html.twig
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ app.request.locale }}">
 <head>
     <title>Testpage</title>
 </head>

--- a/tests/Fixtures/config.yml
+++ b/tests/Fixtures/config.yml
@@ -8,7 +8,7 @@ framework:
         strict_requirements: ~
     default_locale: 'en'
     fragments: ~
-    translator: { fallbacks: [en] }
+    translator: { fallbacks: [] }
     http_method_override: true
     test: ~
     profiler:

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -128,11 +128,11 @@ class FunctionalTest extends WebTestCase
      */
     public function testTranslation(string $locale, string $languageProcessing, string $languageInfoFiltered)
     {
-        $this->client->enableProfiler();
-        $crawler = $this->client->request('GET', sprintf('/%s/translation', $locale));
+        $this->client->request('GET', sprintf('/%s/translation', $locale));
         $this->assertSuccessful($response = $this->client->getResponse());
 
         $content = $response->getContent();
+        $this->assertStringContainsString('"name":"noCDN"', $content);
         $this->assertStringNotContainsString('"options":{"language":{"url"', $content);
         $this->assertStringContainsString(sprintf('"processing":"%s"', $languageProcessing), $content);
         $this->assertStringContainsString(sprintf('"infoFiltered":"%s"', $languageInfoFiltered), $content);
@@ -144,6 +144,48 @@ class FunctionalTest extends WebTestCase
             ['en', 'Processing...', '(filtered from _MAX_ total entries)'],
             ['de', 'Bitte warten...', ' (gefiltert von _MAX_ Eintr\u00e4gen)'],
             ['fr', 'Traitement en cours...', '(filtr&eacute; de _MAX_ &eacute;l&eacute;ments au total)'],
+        ];
+    }
+
+    /**
+     * @dataProvider languageInCDNProvider
+     */
+    public function testLanguageInCDN(string $locale)
+    {
+        $this->client->request('GET', sprintf('/%s/translation?cdn', $locale));
+        $this->assertSuccessful($response = $this->client->getResponse());
+
+        $content = $response->getContent();
+        $this->assertStringContainsString('"name":"CDN"', $content);
+        $this->assertStringContainsString('"options":{"language":{"url"', $content);
+    }
+
+    public function languageInCDNProvider(): array
+    {
+        return [
+            ['en'],
+            ['de'],
+            ['fr_FR'],
+        ];
+    }
+
+    /**
+     * @dataProvider languageNotInCDNProvider
+     */
+    public function testLanguageNotInCDN(string $locale)
+    {
+        $this->client->request('GET', sprintf('/%s/translation?cdn', $locale));
+        $this->assertSuccessful($response = $this->client->getResponse());
+
+        $content = $response->getContent();
+        $this->assertStringContainsString('"name":"CDN"', $content);
+        $this->assertStringNotContainsString('"options":{"language":{"url"', $content);
+    }
+
+    public function languageNotInCDNProvider(): array
+    {
+        return [
+            ['ua'],
         ];
     }
 


### PR DESCRIPTION
@jkabat mentioned in #136 that he uses fr_FR as locale. this update should fix this issue when cdn language is configured with supported locale, but used with defined region