### PR TITLE
Add result transformer

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -65,6 +65,11 @@ abstract class AbstractAdapter implements AdapterInterface
             $rows[] = $row;
         }
 
+        $resultTransformer = $state->getDataTable()->getResultTransformer();
+        if (null !== $resultTransformer) {
+            $rows = call_user_func($resultTransformer, $rows);
+        }
+
         return new ArrayResultSet($rows, $query->getTotalRows(), $query->getFilteredRows());
     }
 

--- a/src/Adapter/ArrayAdapter.php
+++ b/src/Adapter/ArrayAdapter.php
@@ -72,6 +72,11 @@ class ArrayAdapter implements AdapterInterface
 
         $data = iterator_to_array($this->processData($state, $this->data, $map));
 
+        $resultTransformer = $state->getDataTable()->getResultTransformer();
+        if (null !== $resultTransformer) {
+            $data = call_user_func($resultTransformer, $data);
+        }
+
         $length = $state->getLength();
         $page = $length > 0 ? array_slice($data, $state->getStart(), $state->getLength()) : $data;
 

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -93,6 +93,9 @@ class DataTable
     /** @var callable */
     protected $transformer;
 
+    /** @var callable */
+    protected $resultTransformer;
+
     /** @var string */
     protected $translationDomain = 'messages';
 
@@ -332,6 +335,14 @@ class DataTable
         return $this->transformer;
     }
 
+    /**
+     * @return callable|null
+     */
+    public function getResultTransformer()
+    {
+        return $this->resultTransformer;
+    }
+
     public function getOptions(): array
     {
         return $this->options;
@@ -439,6 +450,16 @@ class DataTable
     public function setTransformer(callable $formatter)
     {
         $this->transformer = $formatter;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setResultTransformer(callable $transformer)
+    {
+        $this->resultTransformer = $transformer;
 
         return $this;
     }

--- a/tests/Fixtures/AppBundle/DataTable/Type/RegularPersonTableType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/RegularPersonTableType.php
@@ -52,6 +52,11 @@ class RegularPersonTableType implements DataTableTypeInterface
 
                 return $row;
             })
+            ->setResultTransformer(function ($rows) {
+                $rows[1]['firstName'] .= ' transformer';
+
+                return $rows;
+            })
         ;
     }
 }

--- a/tests/Fixtures/AppBundle/DataTable/Type/ServicePersonTableType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/ServicePersonTableType.php
@@ -60,6 +60,11 @@ class ServicePersonTableType implements DataTableTypeInterface
 
                 return $row;
             })
+            ->setResultTransformer(function ($rows) {
+                $rows[1]['company'] .= ' Transformer';
+
+                return $rows;
+            })
             ->createAdapter(ORMAdapter::class, [
                 'entity' => Employee::class,
                 'criteria' => [

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -78,6 +78,7 @@ class FunctionalTest extends WebTestCase
         $this->assertSame('George W.', $json->data[0]->firstName);
         $this->assertSame('BUSH', $json->data[0]->lastName);
         $this->assertSame('01-01-2017', $json->data[0]->lastActivity);
+        $this->assertSame('George H.W. transformer', $json->data[1]->firstName);
 
         $json = $this->callDataTableUrl('/type?_dt=persons&draw=1&search[value]=Bush');
 
@@ -91,6 +92,7 @@ class FunctionalTest extends WebTestCase
         $this->assertSame(2, $json->draw);
         $this->assertStringStartsWith('Company ', $json->data[0]->company);
         $this->assertSame('LastName0 (Company 0)', $json->data[0]->fullName);
+        $this->assertSame('Company 1 Transformer', $json->data[1]->company);
 
         $json = $this->callDataTableUrl('/service?_dt=persons&draw=2&order[0][column]=2&order[0][dir]=desc&search[value]=24&columns[1][search][value]=24');
 


### PR DESCRIPTION
This pull request aims to add a result transformer that behaves just like the row transformer (formatter).

It allows to do a post-processing for entire result, not only for a row.
I use it for a custom PromiseColumn where I collect all the rows and make a single call to database to get result for each row, instead of making as many calls as rows.

I couldn't find any other way of having this functionality and it looks useful. Tests included.

Thanks.