### PR TITLE
Javascript improvements

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -51,7 +51,6 @@ class DataTable
         'orderCellsTop' => true,
         'stateSave' => false,
         'fixedHeader' => false,
-        'scrollX' => false,
     ];
 
     const DEFAULT_TEMPLATE = '@DataTables/datatable_html.html.twig';

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -51,6 +51,7 @@ class DataTable
         'orderCellsTop' => true,
         'stateSave' => false,
         'fixedHeader' => false,
+        'scrollX' => false,
     ];
 
     const DEFAULT_TEMPLATE = '@DataTables/datatable_html.html.twig';

--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -42,7 +42,7 @@
 
         return new Promise((fulfill, reject) => {
             // Perform initial load
-            $.ajax(config.url, {
+            $.ajax(typeof config.url === 'function' ? config.url(null) : config.url, {
                 method: config.method,
                 data: {
                     _dt: config.name,
@@ -52,7 +52,7 @@
                 var baseState;
 
                 // Merge all options from different sources together and add the Ajax loader
-                var dtOpts = $.extend({}, data.options, config.options, options, persistOptions, {
+                var dtOpts = $.extend({}, data.options, typeof config.options === 'function' ? {} : config.options, options, persistOptions, {
                     ajax: function (request, drawCallback, settings) {
                         if (data) {
                             data.draw = request.draw;
@@ -71,16 +71,8 @@
                             }
                         } else {
                             request._dt = config.name;
-                            // Build url for ajax request or use default one.
-                            var url = '';
-                            if (config.urlBuilder && {}.toString.call(config.urlBuilder) === '[object Function]') {
-                                url = config.urlBuilder();
-                            }
-                            if (!url) {
-                                url = config.url;
-                            }
 
-                            $.ajax(url, {
+                            $.ajax(typeof config.url === 'function' ? config.url(dt) : config.url, {
                                 method: config.method,
                                 data: request
                             }).done(function(data) {
@@ -90,8 +82,8 @@
                     }
                 });
 
-                if (!dtOpts.dom) {
-                    delete dtOpts.dom;
+                if (typeof config.options === 'function') {
+                    dtOpts = config.options(dtOpts);
                 }
 
                 root.html(data.template);

--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -71,7 +71,6 @@
                             }
                         } else {
                             request._dt = config.name;
-
                             $.ajax(typeof config.url === 'function' ? config.url(dt) : config.url, {
                                 method: config.method,
                                 data: request

--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -71,7 +71,16 @@
                             }
                         } else {
                             request._dt = config.name;
-                            $.ajax(config.url, {
+                            // Build url for ajax request or use default one.
+                            var url = '';
+                            if (config.urlBuilder && {}.toString.call(config.urlBuilder) === '[object Function]') {
+                                url = config.urlBuilder();
+                            }
+                            if (!url) {
+                                url = config.url;
+                            }
+
+                            $.ajax(url, {
                                 method: config.method,
                                 data: request
                             }).done(function(data) {
@@ -80,6 +89,10 @@
                         }
                     }
                 });
+
+                if (!dtOpts.dom) {
+                    delete dtOpts.dom;
+                }
 
                 root.html(data.template);
                 dt = $('table', root).DataTable(dtOpts);


### PR DESCRIPTION
Hello,

This pull request contains the following improvements:

- allow **scrollX** parameter to configure horizontal scrolling (*false* by default) https://datatables.net/reference/option/scrollX

- when **dom** parameter is null, it is removed from options passed to datatables. I'm using https://datatables.net/examples/styling/bootstrap4 and I want to remove **dom** parameter in order to let the plugin handle it

- allow to configure url for ajax requests that are made after initial call. This happens if the *config* parameter has an additional parameter named **urlBuilder** which is a callback. This callback will be used for ajax requests after initial one. If this callback returns empty, the default *url* parameter is used.

I use the **urlBuilder** option for filtering with LexikFormFilterBundle. Based on selected filters I'm building the url dynamically.

How does this sound? Thanks.