### PR TITLE
Added TwigStringColumn for simple inline templating

### DIFF
--- a/docs/source/index.html.md
+++ b/docs/source/index.html.md
@@ -492,6 +492,33 @@ template | string | Template path resolvable by the Symfony templating component
 
 <aside class="warning">Keep in mind that for most simple use cases a decorated TextColumn will perform better than a full Twig template per row.</aside>
 
+## TwigStringColumn
+
+```php?start_inline=1
+$table->add('link', TwigStringColumn::class, [
+    'template' => '<a href="{{ url(\'employee.edit\', {id: row.id}) }}">{{ row.firstName }} {{ row.lastName }}</a>',
+])
+```
+
+This column type allows you to inline a Twig template as a string used to render the column's cells. The
+template is rendered using the main application context by injecting the main Twig service.
+Additionally, the `value` and `row` parameters are being filled by the cell value and the row
+level context respectively.
+
+This column type requires `StringLoaderExtension` to be [enabled in your Twig environment](https://symfony.com/doc/4.4/reference/dic_tags.html#twig-extension).
+
+```yaml
+services:
+    Twig\Extension\StringLoaderExtension:
+        tags: [twig.extension]
+```
+
+Option | Type | Description
+------ | ---- | -----------
+template | string | Template content resolvable by the Symfony templating component. Required without default.
+
+<aside class="warning">Keep in mind that for most simple use cases a decorated TextColumn will perform better than a full Twig template per row.</aside>
+
 ## Implementing custom columns
 
 TBD.

--- a/src/Column/TwigColumn.php
+++ b/src/Column/TwigColumn.php
@@ -24,7 +24,7 @@ use Twig\Environment;
 class TwigColumn extends AbstractColumn
 {
     /** @var Environment */
-    private $twig;
+    protected $twig;
 
     /**
      * TwigColumn constructor.
@@ -32,7 +32,7 @@ class TwigColumn extends AbstractColumn
     public function __construct(Environment $twig = null)
     {
         if (null === ($this->twig = $twig)) {
-            throw new MissingDependencyException('You must have TwigBundle installed to use ' . self::class);
+            throw new MissingDependencyException('You must have TwigBundle installed to use ' . static::class);
         }
     }
 

--- a/src/Column/TwigStringColumn.php
+++ b/src/Column/TwigStringColumn.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Column;
+
+use Omines\DataTablesBundle\Exception\MissingDependencyException;
+use Twig\Environment;
+use Twig\Extension\StringLoaderExtension;
+
+/**
+ * TwigStringColumn.
+ *
+ * @author Marek Víger <marek.viger@gmail.com>
+ */
+class TwigStringColumn extends TwigColumn
+{
+    /**
+     * TwigStringColumn constructor.
+     */
+    public function __construct(Environment $twig = null)
+    {
+        parent::__construct($twig);
+
+        if (!$this->twig->hasExtension(StringLoaderExtension::class)) {
+            throw new MissingDependencyException('You must have StringLoaderExtension enabled to use ' . self::class);
+        }
+    }
+
+    protected function render($value, $context)
+    {
+        return $this->twig->render('@DataTables/Column/twig_string.html.twig', [
+            'column_template' => $this->getTemplate(),
+            'row' => $context,
+            'value' => $value,
+        ]);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -20,6 +20,9 @@
         <service id="Omines\DataTablesBundle\Column\TwigColumn">
             <argument type="service" id="twig" on-invalid="null" />
         </service>
+        <service id="Omines\DataTablesBundle\Column\TwigStringColumn">
+            <argument type="service" id="twig" on-invalid="null" />
+        </service>
 
         <!-- Exporters -->
         <service id="Omines\DataTablesBundle\Exporter\DataTableExporterCollection">

--- a/src/Resources/views/Column/twig_string.html.twig
+++ b/src/Resources/views/Column/twig_string.html.twig
@@ -1,0 +1,1 @@
+{{- include(template_from_string(column_template)) -}}

--- a/tests/Fixtures/AppBundle/Controller/PlainController.php
+++ b/tests/Fixtures/AppBundle/Controller/PlainController.php
@@ -17,6 +17,7 @@ use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Omines\DataTablesBundle\Column\DateTimeColumn;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\Column\TwigColumn;
+use Omines\DataTablesBundle\Column\TwigStringColumn;
 use Omines\DataTablesBundle\DataTable;
 use Omines\DataTablesBundle\DataTableFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -45,6 +46,9 @@ class PlainController extends AbstractController
                 },
             ])
             ->add('employer', TextColumn::class, ['field' => 'company.name'])
+            ->add('link', TwigStringColumn::class, [
+                'template' => '<a href="{{ url(\'employee.edit\', {id: row.id}) }}">{{ row.firstName }} {{ row.lastName }}</a>',
+            ])
             ->add('buttons', TwigColumn::class, [
                 'template' => '@App/buttons.html.twig',
                 'data' => '<button>Click me</button>',

--- a/tests/Fixtures/services.yml
+++ b/tests/Fixtures/services.yml
@@ -21,6 +21,11 @@ services:
         arguments:
             - '@doctrine.system_cache_pool'
 
+    twig.extension.string_loader:
+        class: Twig\Extension\StringLoaderExtension
+        tags:
+            - { name: twig.extension }
+
     test.Omines\DataTablesBundle\Exporter\DataTableExporterCollection: '@Omines\DataTablesBundle\Exporter\DataTableExporterCollection'
 
     Tests\Fixtures\AppBundle\DataTable\Exporter\TxtExporter:

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -64,6 +64,7 @@ class FunctionalTest extends WebTestCase
         $this->assertSame('LastName94', $sample->lastName);
         $this->assertEmpty($sample->employedSince);
         $this->assertSame('FirstName94 &lt;img src=&quot;https://symfony.com/images/v5/logos/sf-positive.svg&quot;&gt; LastName94', $sample->fullName);
+        $this->assertSame('<a href="http://localhost/employee/95">FirstName94 LastName94</a>', $sample->link);
         $this->assertRegExp('#href="/employee/[0-9]+"#', $sample->buttons);
 
         $this->assertSame('04-07-2016', $json->data[6]->employedSince);

--- a/tests/Unit/ColumnTest.php
+++ b/tests/Unit/ColumnTest.php
@@ -18,11 +18,13 @@ use Omines\DataTablesBundle\Column\MapColumn;
 use Omines\DataTablesBundle\Column\NumberColumn;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\Column\TwigColumn;
+use Omines\DataTablesBundle\Column\TwigStringColumn;
 use Omines\DataTablesBundle\DataTable;
 use Omines\DataTablesBundle\Exception\MissingDependencyException;
 use Omines\DataTablesBundle\Exporter\DataTableExporterManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Twig\Environment as Twig;
 
 /**
  * ColumnTest.
@@ -140,6 +142,14 @@ class ColumnTest extends TestCase
         $this->expectExceptionMessage('You must have TwigBundle installed to use');
 
         new TwigColumn();
+    }
+
+    public function testTwigStringColumnExtensionDetection()
+    {
+        $this->expectException(MissingDependencyException::class);
+        $this->expectExceptionMessage('You must have StringLoaderExtension enabled to use');
+
+        new TwigStringColumn($this->createMock(Twig::class));
     }
 
     private function createDataTable(): DataTable


### PR DESCRIPTION
This column introduces simple inline templating when you don't want to use TextColumn or don't want to create template files consisting of one line of code

```
->add('link', TwigStringColumn::class, [
    'template' => '<a href="{{ url(\'employee.edit\', {id: row.id}) }}">{{ row.firstName }} {{ row.lastName }}</a>',
])
```