### PR TITLE
Added the ability for column filter to be callable

### DIFF
--- a/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
+++ b/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
@@ -41,6 +41,11 @@ class SearchCriteriaProvider implements QueryBuilderProcessorInterface
             $search = $searchInfo['search'];
 
             if ('' !== trim($search)) {
+                if (is_callable($column->getFilter())) {
+                    call_user_func($column->getFilter(), $queryBuilder, $column->getField(), $search);
+                    continue;
+                }
+
                 if (null !== ($filter = $column->getFilter())) {
                     if (!$filter->isValidValue($search)) {
                         continue;

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -129,7 +129,7 @@ abstract class AbstractColumn
             ->setAllowedTypes('orderField', ['null', 'string'])
             ->setAllowedTypes('searchable', ['null', 'boolean'])
             ->setAllowedTypes('globalSearchable', ['null', 'boolean'])
-            ->setAllowedTypes('filter', ['null', AbstractFilter::class])
+            ->setAllowedTypes('filter', ['null', AbstractFilter::class, 'callable'])
             ->setAllowedTypes('className', ['null', 'string'])
             ->setAllowedTypes('render', ['null', 'string', 'callable'])
             ->setAllowedTypes('operator', ['string'])
@@ -198,7 +198,7 @@ abstract class AbstractColumn
     }
 
     /**
-     * @return AbstractFilter
+     * @return AbstractFilter|callable
      */
     public function getFilter()
     {


### PR DESCRIPTION
This PR adds the ability make `filter` callable.

```
'filter' => function (QueryBuilder $queryBuilder, $field, $search) {
	$users = explode(',', str_replace(' ', '', $search));

    $queryBuilder
    	->andWhere($queryBuilder->expr()->in($field, ':users'))
		->setParameter('users', $users);
}
```