### PR TITLE
Fix symfony 4.4 deprecation notice

### DIFF
--- a/src/Adapter/Doctrine/FetchJoinORMAdapter.php
+++ b/src/Adapter/Doctrine/FetchJoinORMAdapter.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Omines\DataTablesBundle\Adapter\AdapterQuery;
 use Omines\DataTablesBundle\Adapter\Doctrine\Event\ORMAdapterQueryEvent;
-use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapterEvents;
 use Omines\DataTablesBundle\Column\AbstractColumn;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -24,6 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Similar to ORMAdapter this class allows to access objects from the doctrine ORM.
  * Unlike the default ORMAdapter supports Fetch Joins (additional entites are fetched from DB via joins) using
  * the Doctrine Paginator.
+ *
  * @author Jan Böhmer
  */
 class FetchJoinORMAdapter extends ORMAdapter
@@ -43,7 +43,7 @@ class FetchJoinORMAdapter extends ORMAdapter
         //Enforce object hydration mode (fetch join only works for objects)
         $resolver->addAllowedValues('hydrate', Query::HYDRATE_OBJECT);
 
-        /**
+        /*
          * Add the possibility to replace the query for total entity count through a very simple one, to improve performance.
          * You can only use this option, if you did not apply any criteria to your total count.
          */
@@ -120,6 +120,7 @@ class FetchJoinORMAdapter extends ORMAdapter
     public function getCount(QueryBuilder $queryBuilder, $identifier)
     {
         $paginator = new Paginator($queryBuilder);
+
         return $paginator->count();
     }
 
@@ -130,6 +131,7 @@ class FetchJoinORMAdapter extends ORMAdapter
          */
         /** @var Query\Expr\From $from_expr */
         $from_expr = $queryBuilder->getDQLPart('from')[0];
+
         return $this->manager->getRepository($from_expr->getFrom())->count([]);
     }
 }

--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle\Adapter\Doctrine;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
 use Omines\DataTablesBundle\Adapter\AbstractAdapter;
 use Omines\DataTablesBundle\Adapter\AdapterQuery;
 use Omines\DataTablesBundle\Adapter\Doctrine\Event\ORMAdapterQueryEvent;
@@ -286,7 +286,7 @@ class ORMAdapter extends AbstractAdapter
         }
 
         if (Query::HYDRATE_ARRAY === $this->hydrationMode) {
-            return '['.implode('][', array_reverse($path)).']';
+            return '[' . implode('][', array_reverse($path)) . ']';
         } else {
             return implode('.', array_reverse($path));
         }

--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle\Adapter\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
@@ -222,6 +222,7 @@ class ORMAdapter extends AbstractAdapter
 
     /**
      * @param $identifier
+     *
      * @return int
      */
     protected function getCount(QueryBuilder $queryBuilder, $identifier)
@@ -245,6 +246,7 @@ class ORMAdapter extends AbstractAdapter
     /**
      * @param $identifier
      * @param Query\Expr\GroupBy[] $gbList
+     *
      * @return bool
      */
     protected function hasGroupByPart($identifier, array $gbList)
@@ -260,6 +262,7 @@ class ORMAdapter extends AbstractAdapter
 
     /**
      * @param string $field
+     *
      * @return string
      */
     protected function mapFieldToPropertyPath($field, array $aliases = [])
@@ -283,7 +286,7 @@ class ORMAdapter extends AbstractAdapter
         }
 
         if (Query::HYDRATE_ARRAY === $this->hydrationMode) {
-            return '[' . implode('][', array_reverse($path)) . ']';
+            return '['.implode('][', array_reverse($path)).']';
         } else {
             return implode('.', array_reverse($path));
         }
@@ -315,6 +318,7 @@ class ORMAdapter extends AbstractAdapter
 
     /**
      * @param callable|QueryBuilderProcessorInterface $provider
+     *
      * @return QueryBuilderProcessorInterface
      */
     private function normalizeProcessor($provider)


### PR DESCRIPTION
In Symfony >= 4.4, this PR will fix warning deprecation message:

> The "Doctrine\Bundle\DoctrineBundle\Registry" class implements "Symfony\Bridge\Doctrine\RegistryInterface" that is deprecated since Symfony 4.4, use Doctrine\Persistence\ManagerRegistry instead.

