### PR TITLE
Needs This Dependency To Avoid Error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "symfony/phpunit-bridge": "^4.4|^5.0",
         "symfony/twig-bundle": "^4.4|^5.0",
         "symfony/var-dumper": "^4.4|^5.0",
-        "symfony/yaml": "^4.4|^5.0"
+        "symfony/yaml": "^4.4|^5.0",
         "symfony/options-resolver": "^4.4|^5.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "symfony/twig-bundle": "^4.4|^5.0",
         "symfony/var-dumper": "^4.4|^5.0",
         "symfony/yaml": "^4.4|^5.0"
+        "symfony/options-resolver": "^4.4|^5.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "For integrated access to Doctrine object managers",


### PR DESCRIPTION
Need this dependency to avoid "Attempted to load class "OptionsResolver" from namespace "Symfony\Component\OptionsResolver". Did you forget a "use" statement for another namespace?"
At ```        $resolver = new OptionsResolver();
```