### PR TITLE
(WIP - Discussion) Render columns like in form_row

### DIFF
--- a/src/Adapter/ArrayAdapter.php
+++ b/src/Adapter/ArrayAdapter.php
@@ -59,6 +59,18 @@ class ArrayAdapter implements AdapterInterface
             // ignore exception
         }
 
+        $map = $this->getPropertyMap($state);
+        
+        $data = iterator_to_array($this->processData($state, $this->data, $map));
+
+        $length = $state->getLength();
+        $page = $length > 0 ? array_slice($data, $state->getStart(), $state->getLength()) : $data;
+
+        return new ArrayResultSet($page, count($this->data), count($data));
+    }
+
+    protected function getPropertyMap($state): array
+    {
         $map = [];
         foreach ($state->getDataTable()->getColumns() as $column) {
             unset($propertyPath);
@@ -69,13 +81,7 @@ class ArrayAdapter implements AdapterInterface
                 $map[$column->getName()] = $propertyPath;
             }
         }
-
-        $data = iterator_to_array($this->processData($state, $this->data, $map));
-
-        $length = $state->getLength();
-        $page = $length > 0 ? array_slice($data, $state->getStart(), $state->getLength()) : $data;
-
-        return new ArrayResultSet($page, count($this->data), count($data));
+        return $map;
     }
 
     /**

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -68,7 +68,11 @@ abstract class AbstractColumn
             $value = $data;
         }
 
-        return $this->render($this->normalize($value), $context);
+        $value = $this->render($this->normalize($value), $context);
+        if (null !== ($columnRenderer = $this->dataTable->getColumnRenderer())) {
+            $value = $columnRenderer($this, $value, $context);
+        }
+        return $value;
     }
 
     /**

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -312,6 +312,27 @@ class DataTable
         return JsonResponse::create($response);
     }
 
+    public function render($template, $templateParams = []): Response
+    {
+        if (null === $this->state) {
+            throw new InvalidStateException('The DataTable does not know its state yet, did you call handleRequest?');
+        }
+
+        $resultSet = $this->getResultSet();
+        $response = [
+            'draw' => $this->state->getDraw(),
+            'recordsTotal' => $resultSet->getTotalRecords(),
+            'recordsFiltered' => $resultSet->getTotalDisplayRecords(),
+            'data' => $this->renderer->renderResultSet($resultSet->getData(), $template, $templateParams),
+        ];
+        if ($this->state->isInitial()) {
+            $response['options'] = $this->getInitialResponse();
+            $response['template'] = $this->renderer->renderDataTable($this, $this->template, $this->templateParams);
+        }
+
+        return JsonResponse::create($response);
+    }
+
     protected function getInitialResponse(): array
     {
         return array_merge($this->getOptions(), [

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -110,6 +110,8 @@ class DataTable
     /** @var Instantiator */
     private $instantiator;
 
+    private $columnRenderer;
+
     /**
      * DataTable constructor.
      */
@@ -258,6 +260,16 @@ class DataTable
         return (null === $this->state) ? false : $this->state->isCallback();
     }
 
+    public function setColumnTheme(string $theme)
+    {
+        $this->columnRenderer = $this->renderer->getColumnRenderer($theme);
+    }
+
+    public function getColumnRenderer()
+    {
+        return $this->columnRenderer;
+    }
+
     /**
      * @return $this
      */
@@ -303,27 +315,6 @@ class DataTable
             'recordsTotal' => $resultSet->getTotalRecords(),
             'recordsFiltered' => $resultSet->getTotalDisplayRecords(),
             'data' => iterator_to_array($resultSet->getData()),
-        ];
-        if ($this->state->isInitial()) {
-            $response['options'] = $this->getInitialResponse();
-            $response['template'] = $this->renderer->renderDataTable($this, $this->template, $this->templateParams);
-        }
-
-        return JsonResponse::create($response);
-    }
-
-    public function render($template, $templateParams = []): Response
-    {
-        if (null === $this->state) {
-            throw new InvalidStateException('The DataTable does not know its state yet, did you call handleRequest?');
-        }
-
-        $resultSet = $this->getResultSet();
-        $response = [
-            'draw' => $this->state->getDraw(),
-            'recordsTotal' => $resultSet->getTotalRecords(),
-            'recordsFiltered' => $resultSet->getTotalDisplayRecords(),
-            'data' => $this->renderer->renderResultSet($resultSet->getData(), $template, $templateParams),
         ];
         if ($this->state->isInitial()) {
             $response['options'] = $this->getInitialResponse();

--- a/src/DataTableRendererInterface.php
+++ b/src/DataTableRendererInterface.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle;
 
-use Iterator;
-
 /**
  * DataTableRendererInterface.
  *
@@ -26,5 +24,5 @@ interface DataTableRendererInterface
      */
     public function renderDataTable(DataTable $dataTable, string $template, array $parameters): string;
 
-    public function renderResultSet(Iterator $resultSet, string $template, array $parameters): array;
+    public function getColumnRenderer($template): callable;
 }

--- a/src/DataTableRendererInterface.php
+++ b/src/DataTableRendererInterface.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle;
 
+use Iterator;
+
 /**
  * DataTableRendererInterface.
  *
@@ -23,4 +25,6 @@ interface DataTableRendererInterface
      * Provides the HTML layout of the configured datatable.
      */
     public function renderDataTable(DataTable $dataTable, string $template, array $parameters): string;
+
+    public function renderResultSet(Iterator $resultSet, string $template, array $parameters): array;
 }

--- a/src/Twig/TwigRenderer.php
+++ b/src/Twig/TwigRenderer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle\Twig;
 
+use Iterator;
 use Omines\DataTablesBundle\DataTable;
 use Omines\DataTablesBundle\DataTableRendererInterface;
 use Omines\DataTablesBundle\Exception\MissingDependencyException;
@@ -47,5 +48,25 @@ class TwigRenderer implements DataTableRendererInterface
         $parameters['datatable'] = $dataTable;
 
         return $this->twig->render($template, $parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderResultSet(Iterator $resultSet, string $template, array $parameters): array
+    {
+        $renderer = $this->twig->load($template);
+
+        $result = [];
+        foreach($resultSet as $row) {
+            foreach($row as $key=>$cell) {
+                if($key == 'DT_RowId') continue;
+                $params = array_merge($parameters, ["value" => $cell]);
+                $row[$key] = $renderer->renderBlock($key . '_row', $params);
+            }
+            $result[] = $row;
+        }
+
+        return $result;
     }
 }

--- a/src/Twig/TwigRenderer.php
+++ b/src/Twig/TwigRenderer.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle\Twig;
 
-use Iterator;
 use Omines\DataTablesBundle\DataTable;
 use Omines\DataTablesBundle\DataTableRendererInterface;
 use Omines\DataTablesBundle\Exception\MissingDependencyException;
@@ -53,20 +52,22 @@ class TwigRenderer implements DataTableRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function renderResultSet(Iterator $resultSet, string $template, array $parameters): array
+    public function getColumnRenderer($template): callable
     {
         $renderer = $this->twig->load($template);
 
-        $result = [];
-        foreach($resultSet as $row) {
-            foreach($row as $key=>$cell) {
-                if($key == 'DT_RowId') continue;
-                $params = array_merge($parameters, ["value" => $cell]);
-                $row[$key] = $renderer->renderBlock($key . '_row', $params);
+        return function ($column, $value, $context) use ($renderer) {
+            $params = [
+                '_column' => $column,
+                'value' => $value,
+                'context' => $context,
+            ];
+            $blockName = $column->getName() . '_column';
+            if ($renderer->hasBlock($blockName)) {
+                return $renderer->renderBlock($blockName, $params);
+            } else {
+                return $value;
             }
-            $result[] = $row;
-        }
-
-        return $result;
+        };
     }
 }


### PR DESCRIPTION
Hi ! 

NOTE : This PR is just a Work In Progress and a request for feedback. It is not intended for merging.

First thank you for this project, it is AWESOME! I love the way it has a clear syntax that is quite like the original Symfony Forms.

The only thing that bothers me a little is the rendering that leads to html in php which I don't like so much. Of course, there is the TwigColumn, but, as said in the doc, it adds a lot of overhead. I was then thinking of finding a way to do this, in a way more like the Forms. 

As you know, Forms use form themes with blocks  like `form_widget `, so I was thinking, maybe it could be possible to have the same approach for columns, by having one twig template with many blocks like `mycolumn_column` (where `mycolumn` is the name of the column declared in the datatable) where we can do the formatting in the block. This has the main advantage of loading only one twig where all the blocks are declared, and using it for each row and column.

If you think it is a good way for improvment let me know ;-)

Example of a table theme:
```
{% block id_column %}{{value}}{% endblock %} {# blocks can be declared optionally, this one is just for demonstration #}

{% block name_column %}{{value|capitalize}}{% endblock %}

{% block text_column %}{{value|raw}}{% endblock %}

{% block html_column %}{{context.text|nl2br}}{% endblock %}

{% block link_column %}<a href={{ path('my_route', {id : context.id})}}>{{context.name}}</a>{% endblock %}
```