### PR TITLE
Fix depreciations

### DIFF
--- a/src/Adapter/Doctrine/FetchJoinORMAdapter.php
+++ b/src/Adapter/Doctrine/FetchJoinORMAdapter.php
@@ -114,7 +114,6 @@ class FetchJoinORMAdapter extends ORMAdapter
 
         foreach ($paginator->getIterator() as $result) {
             yield $result;
-            $this->manager->detach($result);
         }
     }
 

--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -193,10 +193,7 @@ class ORMAdapter extends AbstractAdapter
         $state->getDataTable()->getEventDispatcher()->dispatch($event, ORMAdapterEvents::PRE_QUERY);
 
         foreach ($query->iterate([], $this->hydrationMode) as $result) {
-            yield $entity = array_values($result)[0];
-            if (Query::HYDRATE_OBJECT === $this->hydrationMode) {
-                $this->manager->detach($entity);
-            }
+            yield array_values($result)[0];
         }
     }
 

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -309,7 +309,7 @@ class DataTable
             $response['template'] = $this->renderer->renderDataTable($this, $this->template, $this->templateParams);
         }
 
-        return JsonResponse::create($response);
+        return new JsonResponse($response);
     }
 
     protected function getInitialResponse(): array

--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -91,7 +91,7 @@ class DataTableState
         $this->start = (int) $parameters->get('start', $this->start);
         $this->length = (int) $parameters->get('length', $this->length);
 
-        $search = $parameters->get('search', []);
+        $search = $parameters->all('search');
         $this->setGlobalSearch($search['value'] ?? $this->globalSearch);
 
         $this->handleOrderBy($parameters);
@@ -102,7 +102,7 @@ class DataTableState
     {
         if ($parameters->has('order')) {
             $this->orderBy = [];
-            foreach ($parameters->get('order', []) as $order) {
+            foreach ($parameters->all('order') as $order) {
                 $column = $this->getDataTable()->getColumn((int) $order['column']);
                 $this->addOrderBy($column, $order['dir'] ?? DataTable::SORT_ASCENDING);
             }
@@ -111,7 +111,7 @@ class DataTableState
 
     private function handleSearch(ParameterBag $parameters)
     {
-        foreach ($parameters->get('columns', []) as $key => $search) {
+        foreach ($parameters->all('columns') as $key => $search) {
             $column = $this->dataTable->getColumn((int) $key);
             $value = $this->isInitial ? $search : $search['search']['value'];
 


### PR DESCRIPTION
This PR aims at fixing depreciations. 

Each fixed depreciation is in a single commit so you can cherry pick them if you disagree with some changes (I'm thinking of the removal of `EntityManager::detach` : https://github.com/omines/datatables-bundle/issues/175#issuecomment-694849158)

**Details :** 

https://github.com/omines/datatables-bundle/commit/0373fb52dc78a6be52036a8b0a1f320198bf72fa - Fix Doctrine\ORM\EntityManager::detach depreciation

Should we replace `$this->manager->detach($result);` by `$this->manager->clear();`? [See this](https://speakerdeck.com/dbrumann/what-to-expect-when-doctrine-3-comes-out?slide=58).
Or should the user use the array hydratation mode in case of memory issues?

https://github.com/omines/datatables-bundle/commit/46d3f9e37e35b6f2925fecef2a7f427043438700 - Fix Symfony\Component\HttpFoundation\InputBag::get depreciation

Use `all` instead of `get` to retrieve an array.

https://github.com/omines/datatables-bundle/commit/f341b7a8b63a05f60cdb53145bb0867f8191a062 - Fix Symfony\Component\HttpFoundation\JsonResponse::create depreciation

Use the constructor instead.

**There are two depreciations remaining :** 

> Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

I don't think it is possible to migrate now as this bundle supports PHPUnit 8.5.

> 1) Tests\Functional\FunctionalTest::testPlainDataTable
assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.

Already aware of it : 

https://github.com/omines/datatables-bundle/blob/83e57742c16a6c31bb28721fd4a81b3bfe8f27ce/tests/Functional/FunctionalTest.php#L69-L71