### PR TITLE
Fix php8 deprecation warning

### DIFF
--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -38,7 +38,7 @@ abstract class AbstractColumn
     /** @var array<string, mixed> */
     protected $options;
 
-    public function initialize(string $name, int $index, array $options = [], DataTable $dataTable)
+    public function initialize(string $name, int $index, array $options, DataTable $dataTable)
     {
         $this->name = $name;
         $this->index = $index;


### PR DESCRIPTION
When using this module with PHP8, following deprecated warning is logged:

`PHP Deprecated:  Required parameter $dataTable follows optional parameter $options in /var/www/html/vendor/omines/datatables-bundle/src/Column/AbstractColumn.php on line 41`

Since the `$options` parameter always needs to be set (because `$dataTable` is required), we can safely remove the default value for `$options`.