### PR TITLE
[Symfony 6] add strict typing where necessary

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -1,0 +1,40 @@
+# .github/workflows/code_checks.yaml
+# TODO Needs improvement
+name: Code_Checks
+
+on: ["push", "pull_request"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        stability: [ prefer-lowest, prefer-stable ]
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} tests
+    steps:
+      # basically git clone
+      - uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+      # use PHP of specific version
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: pcov, dom, curl, libxml, mbstring, mongodb
+          coverage: pcov
+
+      - name: Install dependencies
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/simple-phpunit --verbose
+        env:
+          SYMFONY_DEPRECATIONS_HELPER: weak

--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -35,6 +35,8 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/simple-phpunit --verbose
+        run: |
+          ./tests/cache-warmup.php
+          vendor/bin/simple-phpunit --verbose
         env:
           SYMFONY_DEPRECATIONS_HELPER: weak

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-zip": "*",
         "doctrine/common": "^2.6|^3.0",
         "doctrine/doctrine-bundle": "^2.3|^3.0",
-        "doctrine/orm": "^2.6.3",
+        "doctrine/orm": "^2.6.3 <2.10",
         "doctrine/persistence": "^1.3.4|^2.0",
         "friendsofphp/php-cs-fixer": "^2.7",
         "mongodb/mongodb": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-pdo_sqlite": "*",
         "ext-zip": "*",
         "doctrine/common": "^2.6|^3.0",
-        "doctrine/doctrine-bundle": "^2.3|^3.0",
+        "doctrine/doctrine-bundle": "^2.4.1|^3.0",
         "doctrine/orm": "^2.6.3 <2.10",
         "doctrine/persistence": "^1.3.4|^2.0",
         "friendsofphp/php-cs-fixer": "^2.7",
@@ -66,11 +66,7 @@
         "psr-4": { "Tests\\": "tests/"}
     },
     "config": {
-        "preferred-install": "dist",
-        "sort-packages": true,
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true
-        }
+        "preferred-install": "dist"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "ext-zip": "*",
         "doctrine/common": "^2.6|^3.0",
         "doctrine/doctrine-bundle": "^2.4.1|^3.0",
+        "doctrine/lexer": "^1.1",
         "doctrine/orm": "^2.6.3 <2.10",
         "doctrine/persistence": "^1.3.4|^2.0",
         "friendsofphp/php-cs-fixer": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,10 @@
     },
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/src/Twig/DataTablesExtension.php
+++ b/src/Twig/DataTablesExtension.php
@@ -31,7 +31,7 @@ class DataTablesExtension extends \Twig\Extension\AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new \Twig\TwigFunction('datatable_settings', function (DataTable $dataTable) {
@@ -47,10 +47,7 @@ class DataTablesExtension extends \Twig\Extension\AbstractExtension
         ];
     }
 
-    /**
-     * @return array
-     */
-    private function getLanguageSettings(DataTable $dataTable)
+    private function getLanguageSettings(DataTable $dataTable): array
     {
         if ($dataTable->isLanguageFromCDN() && null !== ($cdnFile = $this->getCDNLanguageFile())) {
             return ['url' => '//cdn.datatables.net/plug-ins/1.10.15/i18n/' . $cdnFile];
@@ -88,7 +85,7 @@ class DataTablesExtension extends \Twig\Extension\AbstractExtension
      *
      * @return string The extension name
      */
-    public function getName()
+    public function getName(): string
     {
         return 'DataTablesBundle';
     }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -67,7 +67,9 @@ class FunctionalTest extends WebTestCase
         $this->assertSame('<a href="http://localhost/employee/95">FirstName94 LastName94</a>', $sample->link);
 
         // Change when we drop old PHP versions and thus old PHPunit versions
-        $this->assertRegExp('#href="/employee/[0-9]+"#', $sample->buttons);
+        method_exists($this, 'assertMatchesRegularExpression')
+            ? $this->assertMatchesRegularExpression('#href="/employee/[0-9]+"#', $sample->buttons)
+            : $this->assertRegExp('#href="/employee/[0-9]+"#', $sample->buttons);
         //$this->assertMatchesRegularExpression('#href="/employee/[0-9]+"#', $sample->buttons);
         $this->assertSame('04-07-2016', $json->data[6]->employedSince);
     }

--- a/tests/Unit/Exporter/DataTableExporterCollectionTest.php
+++ b/tests/Unit/Exporter/DataTableExporterCollectionTest.php
@@ -30,7 +30,8 @@ class DataTableExporterCollectionTest extends KernelTestCase
     public function testUnknownExporter()
     {
         static::expectException(UnknownDataTableExporterException::class);
-        static::$container
+        $container = is_callable([static::class, 'getContainer']) ? static::getContainer() : static::$container;
+        $container
             ->get('Omines\DataTablesBundle\Exporter\DataTableExporterCollection')
             ->getByName('unknown-exporter');
     }

--- a/tests/Unit/Exporter/ExcelExporterTest.php
+++ b/tests/Unit/Exporter/ExcelExporterTest.php
@@ -30,7 +30,9 @@ class ExcelExporterTest extends KernelTestCase
     {
         static::bootKernel();
 
-        $this->exporterCollection = static::$container->get('Omines\DataTablesBundle\Exporter\DataTableExporterCollection');
+        $container = is_callable([static::class, 'getContainer']) ? static::getContainer() : static::$container;
+
+        $this->exporterCollection = $container->get('Omines\DataTablesBundle\Exporter\DataTableExporterCollection');
     }
 
     public function testTag()

--- a/tests/cache-warmup.php
+++ b/tests/cache-warmup.php
@@ -1,0 +1,29 @@
+#!/usr/bin/env php
+<?php
+
+/*
+* Symfony DataTables Bundle
+* (c) Omines Internetbureau B.V. - https://omines.nl/
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+declare(strict_types=1);
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Tests\Fixtures\AppKernel;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$kernel = new AppKernel('test', false);
+$output = new ConsoleOutput();
+$application = new Application($kernel);
+
+try {
+    $application->get('cache:warmup')->run(new StringInput('-vvv'), $output);
+} catch (Exception $e) {
+    // This is presumably okay
+}


### PR DESCRIPTION
Hello, I tried to prepare an internal bundle for symfony 6 and ran into an issue:
```
PHP Fatal error:  Declaration of Omines\DataTablesBundle\DataTablesBundle::getContainerExtension() must be compatible with Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension(): ?Symfony\Component\DependencyInjection\Extension\ExtensionInterface in /vendor/omines/datatables-bundle/src/DataTablesBundle.php on line 40
```
This issue, and the ones that would follow, was resolved by adding the required return types. 

Additionally, running the tests locally with symfony 6 showed 3 more issues, 2 of which I could easily resolve by replacing `static::$container` with `static::getContainer()`. The other one however, I did not figure out. I don't think the test suites will be executed on symfony 6 with the current CI configuration, so that should not be a problem.

Please let me know if anything else should happen before this PR can be accepted / reviewed