### PR TITLE
test: add php 8 versions to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,7 @@ matrix:
        env:
          - SYMFONY_VERSION=^4.4
          - SYMFONY_DEPRECATIONS_HELPER=weak
-     - php: 8.0
-       env:
-         - SYMFONY_DEPRECATIONS_HELPER=weak
-     - php: 8.1
+     - php: nightly
        env:
          - SYMFONY_DEPRECATIONS_HELPER=weak
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
 
 services:
   - mongodb
@@ -28,11 +30,6 @@ matrix:
      # no flag build with code coverage:
      - php: 7.4
        env: ENABLE_CODE_COVERAGE="yes"
-     # --ignore-platform-reqs for ruflin/elastica:6 which doesn't support PHP8
-     - php: 8.0
-       env: COMPOSER_FLAGS="--ignore-platform-reqs"
-     - php: nightly
-       env: COMPOSER_FLAGS="--ignore-platform-reqs"
      # normal build
      - php: 7.2
        env:
@@ -42,12 +39,12 @@ matrix:
        env:
          - SYMFONY_VERSION=^4.4
          - SYMFONY_DEPRECATIONS_HELPER=weak
-     - php: 8.0snapshot
+     - php: 8.0
        env:
-         - DEPENDENCIES=dev
-         - COMPOSER_FLAGS="--ignore-platform-reqs"
-    allow_failures:
-     - php: 8.0snapshot
+         - SYMFONY_DEPRECATIONS_HELPER=weak
+     - php: 8.1
+       env:
+         - SYMFONY_DEPRECATIONS_HELPER=weak
 
 before_install:
   - if [ "$DEPENDENCIES" != "" ]; then composer config minimum-stability ${DEPENDENCIES}; fi;


### PR DESCRIPTION
hi,
this PR tries to add tests for php 8
i do not use Travis. Please check if this is working.

ruflin/elastica:6 is now supporting php8
https://packagist.org/packages/ruflin/elastica
https://packagist.org/packages/ruflin/elastica#6.2.0

Greetz