### PR TITLE
fix: phpoffice/phpspreadsheet set to minimum secured version. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "friendsofphp/php-cs-fixer": "^2.7",
         "mongodb/mongodb": "^1.2",
         "ocramius/package-versions": "^1.4",
-        "phpoffice/phpspreadsheet": "^1.6",
+        "phpoffice/phpspreadsheet": "^1.16",
         "ruflin/elastica": "^6.0|^7.0",
         "symfony/browser-kit": "^4.4|^5.0|^6.0",
         "symfony/css-selector": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
https://packagist.org/packages/phpoffice/phpspreadsheet#1.16.0

https://packagist.org/packages/phpoffice/phpspreadsheet/advisories?version=4536102