### PR TITLE
Move logic to makes queries without limits to the relevant adapters

### DIFF
--- a/src/Adapter/ArrayAdapter.php
+++ b/src/Adapter/ArrayAdapter.php
@@ -72,7 +72,7 @@ class ArrayAdapter implements AdapterInterface
 
         $data = iterator_to_array($this->processData($state, $this->data, $map));
 
-        $length = $state->getLength();
+        $length = $state->getLength() ?? 0;
         $page = $length > 0 ? array_slice($data, $state->getStart(), $state->getLength()) : $data;
 
         return new ArrayResultSet($page, count($this->data), count($data));

--- a/src/Adapter/Doctrine/FetchJoinORMAdapter.php
+++ b/src/Adapter/Doctrine/FetchJoinORMAdapter.php
@@ -100,7 +100,7 @@ class FetchJoinORMAdapter extends ORMAdapter
                 $builder->addOrderBy($column->getOrderField(), $direction);
             }
         }
-        if ($state->getLength() > 0) {
+        if (null !== $state->getLength()) {
             $builder
                 ->setFirstResult($state->getStart())
                 ->setMaxResults($state->getLength());

--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -169,7 +169,7 @@ class ORMAdapter extends AbstractAdapter
                 $builder->addOrderBy($column->getOrderField(), $direction);
             }
         }
-        if ($state->getLength() > 0) {
+        if (null !== $state->getLength()) {
             $builder
                 ->setFirstResult($state->getStart())
                 ->setMaxResults($state->getLength())

--- a/src/Adapter/Elasticsearch/ElasticaAdapter.php
+++ b/src/Adapter/Elasticsearch/ElasticaAdapter.php
@@ -80,7 +80,7 @@ class ElasticaAdapter extends AbstractAdapter
         $search->addIndices($this->indices);
 
         $q = $this->buildQuery($state);
-        if ($state->getLength() > 0) {
+        if (null !== $state->getLength()) {
             $q->setFrom($state->getStart())->setSize($state->getLength());
         }
         $this->applyOrdering($q, $state);

--- a/src/Adapter/MongoDB/MongoDBAdapter.php
+++ b/src/Adapter/MongoDB/MongoDBAdapter.php
@@ -120,7 +120,7 @@ class MongoDBAdapter extends AbstractAdapter
     {
         $options = [
             'limit' => $state->getLength() ?? 0,
-            'skip' => $state->getStart(),
+            'skip' => $state->getLength() ? $state->getStart() : 0,
             'sort' => [],
         ];
 

--- a/src/Adapter/MongoDB/MongoDBAdapter.php
+++ b/src/Adapter/MongoDB/MongoDBAdapter.php
@@ -119,7 +119,7 @@ class MongoDBAdapter extends AbstractAdapter
     private function buildOptions(DataTableState $state): array
     {
         $options = [
-            'limit' => $state->getLength(),
+            'limit' => $state->getLength() ?? 0,
             'skip' => $state->getStart(),
             'sort' => [],
         ];

--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -146,9 +146,9 @@ class DataTableState
 
     public function setStart(int $start): self
     {
-        if ($start < 1) {
-            @trigger_error(sprintf('Calling the "%s::setStart()" method with a length less than 0 is deprecated since version 0.7 of this bundle. Passing a negative value makes no logical sense.', self::class), \E_USER_DEPRECATED);
-            $start = null;
+        if ($start < 0) {
+            @trigger_error(sprintf('Passing a negative value to the "%s::setStart()" method makes no logical sense, defaulting to 0 as the most sane default.', self::class), \E_USER_DEPRECATED);
+            $start = 0;
         }
 
         $this->start = $start;

--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -31,8 +31,8 @@ class DataTableState
     /** @var int */
     private $start = 0;
 
-    /** @var int */
-    private $length = -1;
+    /** @var ?int */
+    private $length = null;
 
     /** @var string */
     private $globalSearch = '';
@@ -49,7 +49,7 @@ class DataTableState
     /** @var bool */
     private $isCallback = false;
 
-    /** @var string */
+    /** @var ?string */
     private $exporterName = null;
 
     /**
@@ -62,10 +62,8 @@ class DataTableState
 
     /**
      * Constructs a state based on the default options.
-     *
-     * @return DataTableState
      */
-    public static function fromDefaults(DataTable $dataTable)
+    public static function fromDefaults(DataTable $dataTable): self
     {
         $state = new self($dataTable);
         $state->start = (int) $dataTable->getOption('start');
@@ -81,7 +79,7 @@ class DataTableState
     /**
      * Loads datatables state from a parameter bag on top of any existing settings.
      */
-    public function applyParameters(ParameterBag $parameters)
+    public function applyParameters(ParameterBag $parameters): void
     {
         $this->draw = $parameters->getInt('draw');
         $this->isCallback = true;
@@ -98,7 +96,7 @@ class DataTableState
         $this->handleSearch($parameters);
     }
 
-    private function handleOrderBy(ParameterBag $parameters)
+    private function handleOrderBy(ParameterBag $parameters): void
     {
         if ($parameters->has('order')) {
             $this->orderBy = [];
@@ -109,7 +107,7 @@ class DataTableState
         }
     }
 
-    private function handleSearch(ParameterBag $parameters)
+    private function handleSearch(ParameterBag $parameters): void
     {
         foreach ($parameters->all()['columns'] ?? [] as $key => $search) {
             $column = $this->dataTable->getColumn((int) $key);
@@ -146,11 +144,13 @@ class DataTableState
         return $this->start;
     }
 
-    /**
-     * @return $this
-     */
-    public function setStart(int $start)
+    public function setStart(int $start): self
     {
+        if ($start < 1) {
+            @trigger_error(sprintf('Calling the "%s::setStart()" method with a length less than 0 is deprecated since version 0.7 of this bundle. Passing a negative value makes no logical sense.', self::class), \E_USER_DEPRECATED);
+            $start = null;
+        }
+
         $this->start = $start;
 
         return $this;
@@ -161,11 +161,13 @@ class DataTableState
         return $this->length;
     }
 
-    /**
-     * @return $this
-     */
-    public function setLength(int $length)
+    public function setLength(?int $length): self
     {
+        if ($length < 1) {
+            @trigger_error(sprintf('Calling the "%s::setLength()" method with a length less than 1 is deprecated since version 0.7 of this bundle. If you need to unrestrict the amount of records returned, pass null instead.', self::class), \E_USER_DEPRECATED);
+            $length = null;
+        }
+
         $this->length = $length;
 
         return $this;
@@ -176,20 +178,14 @@ class DataTableState
         return $this->globalSearch;
     }
 
-    /**
-     * @return $this
-     */
-    public function setGlobalSearch(string $globalSearch)
+    public function setGlobalSearch(string $globalSearch): self
     {
         $this->globalSearch = $globalSearch;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function addOrderBy(AbstractColumn $column, string $direction = DataTable::SORT_ASCENDING)
+    public function addOrderBy(AbstractColumn $column, string $direction = DataTable::SORT_ASCENDING): self
     {
         $this->orderBy[] = [$column, $direction];
 
@@ -201,9 +197,6 @@ class DataTableState
         return $this->orderBy;
     }
 
-    /**
-     * @return $this
-     */
     public function setOrderBy(array $orderBy = []): self
     {
         $this->orderBy = $orderBy;
@@ -219,9 +212,6 @@ class DataTableState
         return $this->searchColumns;
     }
 
-    /**
-     * @return $this
-     */
     public function setColumnSearch(AbstractColumn $column, string $search, bool $isRegex = false): self
     {
         $this->searchColumns[$column->getName()] = ['column' => $column, 'search' => $search, 'regex' => $isRegex];
@@ -229,10 +219,7 @@ class DataTableState
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getExporterName()
+    public function getExporterName(): string
     {
         return $this->exporterName;
     }

--- a/src/Exporter/DataTableExporterManager.php
+++ b/src/Exporter/DataTableExporterManager.php
@@ -118,7 +118,7 @@ class DataTableExporterManager
     {
         $data = $this->dataTable
             ->getAdapter()
-            ->getData($this->dataTable->getState()->setStart(0)->setLength(-1))
+            ->getData($this->dataTable->getState()->setStart(0)->setLength(null))
             ->getData();
 
         foreach ($data as $row) {

--- a/tests/Fixtures/AppBundle/DataTable/Adapter/CustomORMAdapter.php
+++ b/tests/Fixtures/AppBundle/DataTable/Adapter/CustomORMAdapter.php
@@ -40,7 +40,7 @@ class CustomORMAdapter extends ORMAdapter
                 $builder->addOrderBy($column->getOrderField(), $direction);
             }
         }
-        if ($state->getLength() > 0) {
+        if (null !== $state->getLength()) {
             $builder
                 ->setFirstResult($state->getStart())
                 ->setMaxResults($state->getLength());


### PR DESCRIPTION
This PR addresses the issue in #236. The problem there was that the `DataTableExporterManager` was hardcoded to set the length of the result set to -1 to indicate an unrestricted data set. This worked for MySQL, but other data sources potentially have different ways to pass a request for an unlimited amount of results. MongoDB specifically requires a length of 0 to indicate you want as many records as match the query's filters. -1 would result in 0 or 1 records to be returned, which obviously isn't helpful for an exporter.

I moved the responsibility for the specifics into the specific Adapter classes. The `DataTableState` now expects `null` to be passed as a length in order for the responsible adapter to translate that into a query without a limit. In order to do this I did need to change some function signatures (particularly to allow null to be passed) so this _does_ include breaking API changes and warrants a new 0.x release rather than a patch.

I added deprecation notices to the `DataTableState::setLength` and `DataTableState::setStart` methods to warn users that they're using outdated or plain wrong arguments and I'd suggest turning those into hard errors in an eventual 1.x release.