### PR TITLE
feat: add language feature for php8.0, add strong types, adjust tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 Nothing yet.
 
+## [1.0.0] - 2022-03-xx
+### Breaking
+- Add strong php types
+- Add language features from php 8.0
+
 ## [0.7.0] - 2022-03-16
 ### Breaking
 - Move logic to make queries without limits to the relevant adapters (#257)

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -24,8 +24,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
  */
 abstract class AbstractAdapter implements AdapterInterface
 {
-    /** @var PropertyAccessor */
-    protected $accessor;
+    protected PropertyAccessor $accessor;
 
     /**
      * AbstractAdapter constructor.
@@ -80,10 +79,7 @@ abstract class AbstractAdapter implements AdapterInterface
 
     abstract protected function prepareQuery(AdapterQuery $query);
 
-    /**
-     * @return string|null
-     */
-    abstract protected function mapPropertyPath(AdapterQuery $query, AbstractColumn $column);
+    abstract protected function mapPropertyPath(AdapterQuery $query, AbstractColumn $column): ?string;
 
     abstract protected function getResults(AdapterQuery $query): \Traversable;
 }

--- a/src/Adapter/AdapterQuery.php
+++ b/src/Adapter/AdapterQuery.php
@@ -22,104 +22,68 @@ use Omines\DataTablesBundle\DataTableState;
  */
 class AdapterQuery
 {
-    /** @var DataTableState */
-    private $state;
+    private ?int $totalRows;
 
-    /** @var int|null */
-    private $totalRows;
+    private ?int $filteredRows;
 
-    /** @var int|null */
-    private $filteredRows;
-
-    /** @var string|null */
-    private $identifierPropertyPath;
+    private ?string $identifierPropertyPath = null;
 
     /** @var array<string, mixed> */
-    private $data;
+    private array $data;
 
     /**
      * AdapterQuery constructor.
      */
-    public function __construct(DataTableState $state)
-    {
-        $this->state = $state;
-    }
+    public function __construct(private DataTableState $state)
+    {}
 
     public function getState(): DataTableState
     {
         return $this->state;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getTotalRows()
+    public function getTotalRows(): ?int
     {
         return $this->totalRows;
     }
 
-    /**
-     * @param int|null $totalRows
-     * @return $this
-     */
-    public function setTotalRows($totalRows): self
+    public function setTotalRows(?int $totalRows): self
     {
         $this->totalRows = $totalRows;
 
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getFilteredRows()
+    public function getFilteredRows(): ?int
     {
         return $this->filteredRows;
     }
 
-    /**
-     * @param int|null $filteredRows
-     * @return $this
-     */
-    public function setFilteredRows($filteredRows): self
+    public function setFilteredRows(?int $filteredRows): self
     {
         $this->filteredRows = $filteredRows;
 
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getIdentifierPropertyPath()
+    public function getIdentifierPropertyPath(): ?string
     {
         return $this->identifierPropertyPath;
     }
 
-    /**
-     * @param string|null $identifierPropertyPath
-     * @return $this
-     */
-    public function setIdentifierPropertyPath($identifierPropertyPath): self
+    public function setIdentifierPropertyPath(?string $identifierPropertyPath): self
     {
         $this->identifierPropertyPath = $identifierPropertyPath;
 
         return $this;
     }
 
-    /**
-     * @param mixed $default
-     * @return mixed|null
-     */
-    public function get(string $key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         return $this->data[$key] ?? $default;
     }
 
-    /**
-     * @param $value
-     */
-    public function set(string $key, $value)
+    public function set(string $key, mixed $value): void
     {
         $this->data[$key] = $value;
     }

--- a/src/Adapter/ArrayAdapter.php
+++ b/src/Adapter/ArrayAdapter.php
@@ -23,16 +23,14 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
  */
 class ArrayAdapter implements AdapterInterface
 {
-    /** @var array */
-    private $data = [];
+    private array $data = [];
 
-    /** @var PropertyAccessor */
-    private $accessor;
+    private PropertyAccessor $accessor;
 
     /**
      * {@inheritdoc}
      */
-    public function configure(array $options)
+    public function configure(array $options): void
     {
         $this->data = $options;
         $this->accessor = PropertyAccess::createPropertyAccessor();
@@ -78,10 +76,7 @@ class ArrayAdapter implements AdapterInterface
         return new ArrayResultSet($page, count($this->data), count($data));
     }
 
-    /**
-     * @return \Generator
-     */
-    protected function processData(DataTableState $state, array $data, array $map)
+    protected function processData(DataTableState $state, array $data, array $map): \Generator
     {
         $transformer = $state->getDataTable()->getTransformer();
         $search = $state->getGlobalSearch() ?: '';
@@ -95,10 +90,7 @@ class ArrayAdapter implements AdapterInterface
         }
     }
 
-    /**
-     * @return array|null
-     */
-    protected function processRow(DataTableState $state, array $result, array $map, string $search)
+    protected function processRow(DataTableState $state, array $result, array $map, string $search): ?array
     {
         $row = [];
         $match = empty($search);

--- a/src/Adapter/ArrayResultSet.php
+++ b/src/Adapter/ArrayResultSet.php
@@ -19,21 +19,15 @@ namespace Omines\DataTablesBundle\Adapter;
  */
 class ArrayResultSet implements ResultSetInterface
 {
-    /** @var array */
-    private $data;
+    private int $totalRows;
 
-    /** @var int */
-    private $totalRows;
-
-    /** @var int */
-    private $totalFilteredRows;
+    private int $totalFilteredRows;
 
     /**
      * ArrayResultSet constructor.
      */
-    public function __construct(array $data, int $totalRows = null, int $totalFilteredRows = null)
+    public function __construct(private array $data, int $totalRows = null, int $totalFilteredRows = null)
     {
-        $this->data = $data;
         $this->totalRows = $totalRows ?? count($data);
         $this->totalFilteredRows = $totalFilteredRows ?? $this->totalRows;
     }

--- a/src/Adapter/Doctrine/Event/ORMAdapterQueryEvent.php
+++ b/src/Adapter/Doctrine/Event/ORMAdapterQueryEvent.php
@@ -20,16 +20,8 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class ORMAdapterQueryEvent extends Event
 {
-    /** @var Query */
-    protected $query;
-
-    /**
-     * ORMAdapterQueryEvent constructor.
-     */
-    public function __construct(Query $query)
-    {
-        $this->query = $query;
-    }
+    public function __construct(protected Query $query)
+    {}
 
     public function getQuery(): Query
     {

--- a/src/Adapter/Doctrine/FetchJoinORMAdapter.php
+++ b/src/Adapter/Doctrine/FetchJoinORMAdapter.php
@@ -31,7 +31,7 @@ class FetchJoinORMAdapter extends ORMAdapter
 {
     protected $use_simple_total;
 
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): OptionsResolver
     {
         parent::configureOptions($resolver);
 
@@ -54,7 +54,7 @@ class FetchJoinORMAdapter extends ORMAdapter
         $this->use_simple_total = $options['simple_total_query'];
     }
 
-    protected function prepareQuery(AdapterQuery $query)
+    protected function prepareQuery(AdapterQuery $query): void
     {
         $state = $query->getState();
         $query->set('qb', $builder = $this->createQueryBuilder($state));
@@ -119,14 +119,14 @@ class FetchJoinORMAdapter extends ORMAdapter
         }
     }
 
-    public function getCount(QueryBuilder $queryBuilder, $identifier)
+    public function getCount(QueryBuilder $queryBuilder, $identifier): int
     {
         $paginator = new Paginator($queryBuilder);
 
         return $paginator->count();
     }
 
-    protected function getSimpleTotalCount(QueryBuilder $queryBuilder)
+    protected function getSimpleTotalCount(QueryBuilder $queryBuilder): int
     {
         /** The paginator count queries can be rather slow, so when query for total count (100ms or longer),
          * just return the entity count.

--- a/src/Adapter/Doctrine/ORM/AutomaticQueryBuilder.php
+++ b/src/Adapter/Doctrine/ORM/AutomaticQueryBuilder.php
@@ -25,32 +25,19 @@ use Omines\DataTablesBundle\DataTableState;
  */
 class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
 {
-    /** @var EntityManagerInterface */
-    private $em;
+    private string $entityName;
 
-    /** @var ClassMetadata */
-    private $metadata;
+    private string $entityShortName;
 
-    /** @var string */
-    private $entityName;
+    private array $selectColumns = [];
 
-    /** @var string */
-    private $entityShortName;
-
-    /** @var array */
-    private $selectColumns = [];
-
-    /** @var array */
-    private $joins = [];
+    private array $joins = [];
 
     /**
      * AutomaticQueryBuilder constructor.
      */
-    public function __construct(EntityManagerInterface $em, ClassMetadata $metadata)
+    public function __construct(private EntityManagerInterface $em, private ClassMetadata $metadata)
     {
-        $this->em = $em;
-        $this->metadata = $metadata;
-
         $this->entityName = $this->metadata->getName();
         $this->entityShortName = mb_strtolower($this->metadata->getReflectionClass()->getShortName());
     }
@@ -58,7 +45,7 @@ class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function process(QueryBuilder $builder, DataTableState $state)
+    public function process(QueryBuilder $builder, DataTableState $state): void
     {
         if (empty($this->selectColumns) && empty($this->joins)) {
             foreach ($state->getDataTable()->getColumns() as $column) {
@@ -70,7 +57,7 @@ class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
         $this->setJoins($builder);
     }
 
-    protected function processColumn(AbstractColumn $column)
+    protected function processColumn(AbstractColumn $column): void
     {
         $field = $column->getField();
 
@@ -83,7 +70,7 @@ class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
         }
     }
 
-    private function addSelectColumns(AbstractColumn $column, string $field)
+    private function addSelectColumns(AbstractColumn $column, string $field): void
     {
         $currentPart = $this->entityShortName;
         $currentAlias = $currentPart;
@@ -114,7 +101,7 @@ class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
         }
     }
 
-    private function addSelectColumn($columnTableName, $data)
+    private function addSelectColumn($columnTableName, $data): static
     {
         if (isset($this->selectColumns[$columnTableName])) {
             if (!in_array($data, $this->selectColumns[$columnTableName], true)) {
@@ -127,14 +114,14 @@ class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
         return $this;
     }
 
-    private function getIdentifier(ClassMetadata $metadata)
+    private function getIdentifier(ClassMetadata $metadata): ?string
     {
         $identifiers = $metadata->getIdentifierFieldNames();
 
         return array_shift($identifiers);
     }
 
-    private function setIdentifierFromAssociation(string $association, string $key, ClassMetadata $metadata)
+    private function setIdentifierFromAssociation(string $association, string $key, ClassMetadata $metadata): ClassMetadata
     {
         $targetEntityClass = $metadata->getAssociationTargetClass($key);
 
@@ -145,7 +132,7 @@ class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
         return $targetMetadata;
     }
 
-    private function setSelectFrom(QueryBuilder $qb)
+    private function setSelectFrom(QueryBuilder $qb): static
     {
         foreach ($this->selectColumns as $key => $value) {
             if (false === empty($key)) {
@@ -158,7 +145,7 @@ class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
         return $this;
     }
 
-    private function setJoins(QueryBuilder $qb)
+    private function setJoins(QueryBuilder $qb): static
     {
         foreach ($this->joins as $key => $value) {
             $qb->{$value['type']}($key, $value['alias']);

--- a/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
+++ b/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
@@ -27,13 +27,13 @@ class SearchCriteriaProvider implements QueryBuilderProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function process(QueryBuilder $queryBuilder, DataTableState $state)
+    public function process(QueryBuilder $queryBuilder, DataTableState $state): void
     {
         $this->processSearchColumns($queryBuilder, $state);
         $this->processGlobalSearch($queryBuilder, $state);
     }
 
-    private function processSearchColumns(QueryBuilder $queryBuilder, DataTableState $state)
+    private function processSearchColumns(QueryBuilder $queryBuilder, DataTableState $state): void
     {
         foreach ($state->getSearchColumns() as $searchInfo) {
             /** @var AbstractColumn $column */
@@ -52,7 +52,7 @@ class SearchCriteriaProvider implements QueryBuilderProcessorInterface
         }
     }
 
-    private function processGlobalSearch(QueryBuilder $queryBuilder, DataTableState $state)
+    private function processGlobalSearch(QueryBuilder $queryBuilder, DataTableState $state): void
     {
         if (!empty($globalSearch = $state->getGlobalSearch())) {
             $expr = $queryBuilder->expr();

--- a/src/Adapter/Elasticsearch/ElasticaAdapter.php
+++ b/src/Adapter/Elasticsearch/ElasticaAdapter.php
@@ -26,16 +26,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ElasticaAdapter extends AbstractAdapter
 {
-    /** @var array */
-    private $clientSettings = [];
+    private array $clientSettings = [];
 
-    /** @var array */
-    private $indices = [];
+    private array $indices = [];
 
     /**
      * {@inheritdoc}
      */
-    public function configure(array $options)
+    public function configure(array $options): void
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
@@ -45,10 +43,7 @@ class ElasticaAdapter extends AbstractAdapter
         $this->indices = (array) $options['index'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function prepareQuery(AdapterQuery $query)
+    protected function prepareQuery(AdapterQuery $query): void
     {
         if (!class_exists(\Elastica\Client::class)) {
             throw new MissingDependencyException('Install ruflin/elastica to use the ElasticaAdapter');
@@ -65,14 +60,11 @@ class ElasticaAdapter extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    protected function mapPropertyPath(AdapterQuery $query, AbstractColumn $column)
+    protected function mapPropertyPath(AdapterQuery $query, AbstractColumn $column): ?string
     {
         return "[{$column->getField()}]";
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getResults(AdapterQuery $query): \Traversable
     {
         $state = $query->getState();
@@ -114,7 +106,7 @@ class ElasticaAdapter extends AbstractAdapter
         return $q;
     }
 
-    protected function applyOrdering(\Elastica\Query $query, DataTableState $state)
+    protected function applyOrdering(\Elastica\Query $query, DataTableState $state): void
     {
         foreach ($state->getOrderBy() as list($column, $direction)) {
             /** @var AbstractColumn $column */
@@ -124,7 +116,7 @@ class ElasticaAdapter extends AbstractAdapter
         }
     }
 
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/Adapter/MongoDB/MongoDBAdapter.php
+++ b/src/Adapter/MongoDB/MongoDBAdapter.php
@@ -34,16 +34,14 @@ class MongoDBAdapter extends AbstractAdapter
         DataTable::SORT_DESCENDING => -1,
     ];
 
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
-    /** @var array */
-    private $filters;
+    private array $filters;
 
     /**
      * {@inheritdoc}
      */
-    public function configure(array $options)
+    public function configure(array $options): void
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
@@ -56,7 +54,7 @@ class MongoDBAdapter extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    protected function prepareQuery(AdapterQuery $query)
+    protected function prepareQuery(AdapterQuery $query): void
     {
         foreach ($query->getState()->getDataTable()->getColumns() as $column) {
             if (null === $column->getField()) {
@@ -70,7 +68,7 @@ class MongoDBAdapter extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    protected function mapPropertyPath(AdapterQuery $query, AbstractColumn $column)
+    protected function mapPropertyPath(AdapterQuery $query, AbstractColumn $column): ?string
     {
         return '[' . implode('][', explode('.', $column->getField())) . ']';
     }
@@ -134,7 +132,7 @@ class MongoDBAdapter extends AbstractAdapter
         return $options;
     }
 
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -24,21 +24,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 abstract class AbstractColumn
 {
     /** @var array<string, OptionsResolver> */
-    private static $resolversByClass = [];
+    private static array $resolversByClass = [];
 
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var int */
-    private $index;
+    private int $index;
 
-    /** @var DataTable */
-    private $dataTable;
+    private DataTable $dataTable;
 
     /** @var array<string, mixed> */
-    protected $options;
+    protected array $options;
 
-    public function initialize(string $name, int $index, array $options, DataTable $dataTable)
+    public function initialize(string $name, int $index, array $options, DataTable $dataTable): void
     {
         $this->name = $name;
         $this->index = $index;
@@ -57,9 +54,8 @@ abstract class AbstractColumn
      *
      * @param mixed|null $value The single value of the column, if mapping makes it possible to derive one
      * @param mixed|null $context All relevant data of the entire row
-     * @return mixed
      */
-    public function transform($value = null, $context = null)
+    public function transform(mixed $value = null, mixed $context = null): mixed
     {
         $data = $this->getData();
         if (is_callable($data)) {
@@ -74,11 +70,9 @@ abstract class AbstractColumn
     /**
      * Apply final modifications before rendering to result.
      *
-     * @param mixed $value
      * @param mixed $context All relevant data of the entire row
-     * @return mixed|string
      */
-    protected function render($value, $context)
+    protected function render(mixed $value, mixed $context): mixed
     {
         if (is_string($render = $this->options['render'])) {
             return sprintf($render, $value);
@@ -93,14 +87,10 @@ abstract class AbstractColumn
      * The normalize function is responsible for converting parsed and processed data to a datatables-appropriate type.
      *
      * @param mixed $value The single value of the column
-     * @return mixed
      */
-    abstract public function normalize($value);
+    abstract public function normalize(mixed $value): mixed;
 
-    /**
-     * @return $this
-     */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         $resolver
             ->setDefaults([
@@ -150,34 +140,22 @@ abstract class AbstractColumn
         return $this->name;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getLabel()
+    public function getLabel(): ?string
     {
         return $this->options['label'] ?? "{$this->dataTable->getName()}.columns.{$this->getName()}";
     }
 
-    /**
-     * @return string|null
-     */
-    public function getField()
+    public function getField(): ?string
     {
         return $this->options['field'];
     }
 
-    /**
-     * @return string|null
-     */
-    public function getPropertyPath()
+    public function getPropertyPath(): ?string
     {
         return $this->options['propertyPath'];
     }
 
-    /**
-     * @return callable|string|null
-     */
-    public function getData()
+    public function getData(): callable|string|null
     {
         return $this->options['data'];
     }
@@ -197,18 +175,12 @@ abstract class AbstractColumn
         return $this->options['orderable'] ?? !empty($this->getOrderField());
     }
 
-    /**
-     * @return AbstractFilter
-     */
-    public function getFilter()
+    public function getFilter(): ?AbstractFilter
     {
         return $this->options['filter'];
     }
 
-    /**
-     * @return string|null
-     */
-    public function getOrderField()
+    public function getOrderField(): ?string
     {
         return $this->options['orderField'] ?? $this->getField();
     }
@@ -218,10 +190,7 @@ abstract class AbstractColumn
         return $this->options['globalSearchable'] ?? $this->isSearchable();
     }
 
-    /**
-     * @return string
-     */
-    public function getLeftExpr()
+    public function getLeftExpr(): ?string
     {
         $leftExpr = $this->options['leftExpr'];
         if (null === $leftExpr) {
@@ -234,10 +203,7 @@ abstract class AbstractColumn
         return $leftExpr;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getRightExpr($value)
+    public function getRightExpr($value): mixed
     {
         $rightExpr = $this->options['rightExpr'];
         if (null === $rightExpr) {
@@ -250,18 +216,12 @@ abstract class AbstractColumn
         return $rightExpr;
     }
 
-    /**
-     * @return string
-     */
-    public function getOperator()
+    public function getOperator(): string
     {
         return $this->options['operator'];
     }
 
-    /**
-     * @return string
-     */
-    public function getClassName()
+    public function getClassName(): ?string
     {
         return $this->options['className'];
     }
@@ -271,22 +231,14 @@ abstract class AbstractColumn
         return $this->dataTable;
     }
 
-    /**
-     * @param mixed $value
-     * @return $this
-     */
-    public function setOption(string $name, $value): self
+    public function setOption(string $name, mixed $value): self
     {
         $this->options[$name] = $value;
 
         return $this;
     }
 
-    /**
-     * @param string $value
-     * @return bool
-     */
-    public function isValidForSearch($value)
+    public function isValidForSearch(mixed $value): bool
     {
         return true;
     }

--- a/src/Column/BoolColumn.php
+++ b/src/Column/BoolColumn.php
@@ -24,7 +24,7 @@ class BoolColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function normalize($value): string
+    public function normalize(mixed $value): string
     {
         if (null === $value) {
             return $this->getNullValue();
@@ -36,7 +36,7 @@ class BoolColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
 
@@ -75,11 +75,7 @@ class BoolColumn extends AbstractColumn
         return $this->options['nullValue'];
     }
 
-    /**
-     * @param string $value
-     * @return bool
-     */
-    public function isValidForSearch($value)
+    public function isValidForSearch(mixed $value): bool
     {
         $value = trim(mb_strtolower($value));
 

--- a/src/Column/DateTimeColumn.php
+++ b/src/Column/DateTimeColumn.php
@@ -24,7 +24,7 @@ class DateTimeColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function normalize($value)
+    public function normalize(mixed $value): mixed
     {
         if (null === $value) {
             return $this->options['nullValue'];
@@ -48,7 +48,7 @@ class DateTimeColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
 

--- a/src/Column/MapColumn.php
+++ b/src/Column/MapColumn.php
@@ -24,7 +24,7 @@ class MapColumn extends TextColumn
     /**
      * {@inheritdoc}
      */
-    public function normalize($value): string
+    public function normalize(mixed $value): string
     {
         return parent::normalize($this->options['map'][$value] ?? $this->options['default'] ?? $value);
     }
@@ -32,7 +32,7 @@ class MapColumn extends TextColumn
     /**
      * {@inheritdoc}
      */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
 

--- a/src/Column/NumberColumn.php
+++ b/src/Column/NumberColumn.php
@@ -24,7 +24,7 @@ class NumberColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function normalize($value): string
+    public function normalize(mixed $value): string
     {
         $value = (string) $value;
         if (is_numeric($value)) {
@@ -37,7 +37,7 @@ class NumberColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
 
@@ -54,11 +54,7 @@ class NumberColumn extends AbstractColumn
         return $this->options['raw'];
     }
 
-    /**
-     * @param string $value
-     * @return bool
-     */
-    public function isValidForSearch($value)
+    public function isValidForSearch(mixed $value): bool
     {
         return is_numeric($value);
     }

--- a/src/Column/TextColumn.php
+++ b/src/Column/TextColumn.php
@@ -24,7 +24,7 @@ class TextColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function normalize($value): string
+    public function normalize(mixed $value): string
     {
         $value = (string) $value;
 
@@ -34,7 +34,7 @@ class TextColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
 

--- a/src/Column/TwigColumn.php
+++ b/src/Column/TwigColumn.php
@@ -23,15 +23,12 @@ use Twig\Environment;
  */
 class TwigColumn extends AbstractColumn
 {
-    /** @var Environment */
-    protected $twig;
-
     /**
      * TwigColumn constructor.
      */
-    public function __construct(Environment $twig = null)
+    public function __construct(protected ?Environment $twig = null)
     {
-        if (null === ($this->twig = $twig)) {
+        if (null === $this->twig) {
             throw new MissingDependencyException('You must have TwigBundle installed to use ' . static::class);
         }
     }
@@ -39,7 +36,7 @@ class TwigColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function render($value, $context)
+    protected function render(mixed $value, mixed $context): mixed
     {
         return $this->twig->render($this->getTemplate(), [
             'row' => $context,
@@ -50,7 +47,7 @@ class TwigColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function normalize($value)
+    public function normalize(mixed $value): mixed
     {
         return $value;
     }
@@ -58,7 +55,7 @@ class TwigColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
 

--- a/src/Column/TwigStringColumn.php
+++ b/src/Column/TwigStringColumn.php
@@ -35,7 +35,7 @@ class TwigStringColumn extends TwigColumn
         }
     }
 
-    protected function render($value, $context)
+    protected function render(mixed $value, mixed $context): mixed
     {
         return $this->twig->render('@DataTables/Column/twig_string.html.twig', [
             'column_template' => $this->getTemplate(),

--- a/src/Controller/DataTablesTrait.php
+++ b/src/Controller/DataTablesTrait.php
@@ -31,9 +31,8 @@ trait DataTablesTrait
      * Creates and returns a basic DataTable instance.
      *
      * @param array $options Options to be passed
-     * @return DataTable
      */
-    protected function createDataTable(array $options = [])
+    protected function createDataTable(array $options = []): DataTable
     {
         @trigger_error('Omines\DataTablesBundle\Controller\DataTablesTrait is deprecated. Use dependency injection to inject the Omines\DataTablesBundle\DataTableFactory service instead.', E_USER_DEPRECATED);
 
@@ -48,7 +47,7 @@ trait DataTablesTrait
      * @param array $options Options to be passed
      * @return DataTable
      */
-    protected function createDataTableFromType($type, array $typeOptions = [], array $options = [])
+    protected function createDataTableFromType(string $type, array $typeOptions = [], array $options = []): DataTable
     {
         @trigger_error('Omines\DataTablesBundle\Controller\DataTablesTrait is deprecated. Use dependency injection to inject the Omines\DataTablesBundle\DataTableFactory service instead.', E_USER_DEPRECATED);
 

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -59,64 +59,47 @@ class DataTable
     const SORT_ASCENDING = 'asc';
     const SORT_DESCENDING = 'desc';
 
-    /** @var AdapterInterface */
-    protected $adapter;
+    protected ?AdapterInterface $adapter = null;
 
     /** @var AbstractColumn[] */
-    protected $columns = [];
+    protected array $columns = [];
 
     /** @var array<string, AbstractColumn> */
-    protected $columnsByName = [];
+    protected array $columnsByName = [];
 
-    /** @var EventDispatcherInterface */
-    protected $eventDispatcher;
+    protected string $method = Request::METHOD_POST;
 
-    /** @var DataTableExporterManager */
-    protected $exporterManager;
+    protected array $options;
 
-    /** @var string */
-    protected $method = Request::METHOD_POST;
+    protected bool $languageFromCDN = true;
 
-    /** @var array */
-    protected $options;
+    protected string $name = 'dt';
 
-    /** @var bool */
-    protected $languageFromCDN = true;
+    protected string $persistState = 'fragment';
 
-    /** @var string */
-    protected $name = 'dt';
+    protected string $template = self::DEFAULT_TEMPLATE;
 
-    /** @var string */
-    protected $persistState = 'fragment';
-
-    /** @var string */
-    protected $template = self::DEFAULT_TEMPLATE;
-
-    /** @var array */
-    protected $templateParams = [];
+    protected array $templateParams = [];
 
     /** @var callable */
     protected $transformer;
 
-    /** @var string */
-    protected $translationDomain = 'messages';
+    protected string $translationDomain = 'messages';
 
-    /** @var DataTableRendererInterface */
-    private $renderer;
+    private DataTableRendererInterface $renderer;
 
-    /** @var DataTableState */
-    private $state;
+    private ?DataTableState $state = null;
 
-    /** @var Instantiator */
-    private $instantiator;
+    private Instantiator $instantiator;
 
     /**
      * DataTable constructor.
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher, DataTableExporterManager $exporterManager, array $options = [], Instantiator $instantiator = null)
+    public function __construct(protected EventDispatcherInterface $eventDispatcher,
+                                protected DataTableExporterManager $exporterManager,
+                                array                              $options = [],
+                                Instantiator                       $instantiator = null)
     {
-        $this->eventDispatcher = $eventDispatcher;
-        $this->exporterManager = $exporterManager;
 
         $this->instantiator = $instantiator ?? new Instantiator();
 
@@ -125,10 +108,7 @@ class DataTable
         $this->options = $resolver->resolve($options);
     }
 
-    /**
-     * @return $this
-     */
-    public function add(string $name, string $type, array $options = [])
+    public function add(string $name, string $type, array $options = []): static
     {
         // Ensure name is unique
         if (isset($this->columnsByName[$name])) {
@@ -162,11 +142,7 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @param int|string|AbstractColumn $column
-     * @return $this
-     */
-    public function addOrderBy($column, string $direction = self::SORT_ASCENDING)
+    public function addOrderBy(int|string|AbstractColumn $column, string $direction = self::SORT_ASCENDING): static
     {
         if (!$column instanceof AbstractColumn) {
             $column = is_int($column) ? $this->getColumn($column) : $this->getColumnByName((string) $column);
@@ -176,9 +152,6 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function createAdapter(string $adapter, array $options = []): self
     {
         return $this->setAdapter($this->instantiator->getAdapter($adapter), $options);
@@ -240,10 +213,7 @@ class DataTable
         return $this->persistState;
     }
 
-    /**
-     * @return DataTableState|null
-     */
-    public function getState()
+    public function getState(): ?DataTableState
     {
         return $this->state;
     }
@@ -255,12 +225,9 @@ class DataTable
 
     public function isCallback(): bool
     {
-        return (null === $this->state) ? false : $this->state->isCallback();
+        return !(null === $this->state) && $this->state->isCallback();
     }
 
-    /**
-     * @return $this
-     */
     public function handleRequest(Request $request): self
     {
         switch ($this->getMethod()) {
@@ -338,10 +305,7 @@ class DataTable
         return $this->adapter->getData($this->state);
     }
 
-    /**
-     * @return callable|null
-     */
-    public function getTransformer()
+    public function getTransformer(): ?callable
     {
         return $this->transformer;
     }
@@ -351,18 +315,11 @@ class DataTable
         return $this->options;
     }
 
-    /**
-     * @param $name
-     * @return mixed|null
-     */
-    public function getOption($name)
+    public function getOption(string $name): mixed
     {
         return $this->options[$name] ?? null;
     }
 
-    /**
-     * @return DataTable
-     */
     public function setAdapter(AdapterInterface $adapter, array $options = null): self
     {
         if (null !== $options) {
@@ -373,9 +330,6 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setLanguageFromCDN(bool $languageFromCDN): self
     {
         $this->languageFromCDN = $languageFromCDN;
@@ -383,9 +337,6 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setMethod(string $method): self
     {
         $this->method = $method;
@@ -393,9 +344,6 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setPersistState(string $persistState): self
     {
         $this->persistState = $persistState;
@@ -403,9 +351,6 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setRenderer(DataTableRendererInterface $renderer): self
     {
         $this->renderer = $renderer;
@@ -413,9 +358,6 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setName(string $name): self
     {
         if (empty($name)) {
@@ -426,9 +368,6 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setTemplate(string $template, array $parameters = []): self
     {
         $this->template = $template;
@@ -437,9 +376,6 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setTranslationDomain(string $translationDomain): self
     {
         $this->translationDomain = $translationDomain;
@@ -447,20 +383,14 @@ class DataTable
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function setTransformer(callable $formatter)
+    public function setTransformer(callable $formatter): self
     {
         $this->transformer = $formatter;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): self
     {
         $resolver->setDefaults(self::DEFAULT_OPTIONS);
 

--- a/src/DataTableFactory.php
+++ b/src/DataTableFactory.php
@@ -19,40 +19,20 @@ use Symfony\Component\HttpFoundation\Request;
 
 class DataTableFactory
 {
-    /** @var Instantiator */
-    protected $instantiator;
-
-    /** @var DataTableRendererInterface */
-    protected $renderer;
-
     /** @var array<string, DataTableTypeInterface> */
-    protected $resolvedTypes = [];
-
-    /** @var array */
-    protected $config;
-
-    /** @var EventDispatcherInterface */
-    protected $eventDispatcher;
-
-    /** @var DataTableExporterManager */
-    protected $exporterManager;
+    protected array $resolvedTypes = [];
 
     /**
      * DataTableFactory constructor.
      */
-    public function __construct(array $config, DataTableRendererInterface $renderer, Instantiator $instantiator, EventDispatcherInterface $eventDispatcher, DataTableExporterManager $exporterManager)
-    {
-        $this->config = $config;
-        $this->renderer = $renderer;
-        $this->instantiator = $instantiator;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->exporterManager = $exporterManager;
-    }
+    public function __construct(protected array                      $config,
+                                protected DataTableRendererInterface $renderer,
+                                protected Instantiator               $instantiator,
+                                protected EventDispatcherInterface   $eventDispatcher,
+                                protected DataTableExporterManager   $exporterManager)
+    {}
 
-    /**
-     * @return DataTable
-     */
-    public function create(array $options = [])
+    public function create(array $options = []): DataTable
     {
         $config = $this->config;
 
@@ -66,11 +46,8 @@ class DataTableFactory
         ;
     }
 
-    /**
-     * @param string|DataTableTypeInterface $type
-     * @return DataTable
-     */
-    public function createFromType($type, array $typeOptions = [], array $options = [])
+
+    public function createFromType(DataTableTypeInterface|string $type, array $typeOptions = [], array $options = []): DataTable
     {
         $dataTable = $this->create($options);
 

--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -22,43 +22,29 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  */
 class DataTableState
 {
-    /** @var DataTable */
-    private $dataTable;
+    private int $draw = 0;
 
-    /** @var int */
-    private $draw = 0;
+    private int $start = 0;
 
-    /** @var int */
-    private $start = 0;
+    private ?int $length = null;
 
-    /** @var ?int */
-    private $length = null;
+    private string $globalSearch = '';
 
-    /** @var string */
-    private $globalSearch = '';
+    private array $searchColumns = [];
 
-    /** @var array */
-    private $searchColumns = [];
+    private array $orderBy = [];
 
-    /** @var array */
-    private $orderBy = [];
+    private bool $isInitial = false;
 
-    /** @var bool */
-    private $isInitial = false;
+    private bool $isCallback = false;
 
-    /** @var bool */
-    private $isCallback = false;
-
-    /** @var ?string */
-    private $exporterName = null;
+    private ?string $exporterName = null;
 
     /**
      * DataTableState constructor.
      */
-    public function __construct(DataTable $dataTable)
-    {
-        $this->dataTable = $dataTable;
-    }
+    public function __construct(private DataTable $dataTable)
+    {}
 
     /**
      * Constructs a state based on the default options.

--- a/src/DataTablesBundle.php
+++ b/src/DataTablesBundle.php
@@ -28,7 +28,7 @@ class DataTablesBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/DependencyInjection/Compiler/LocatorRegistrationPass.php
+++ b/src/DependencyInjection/Compiler/LocatorRegistrationPass.php
@@ -33,7 +33,7 @@ class LocatorRegistrationPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $container->getDefinition(Instantiator::class)
             ->setArguments([[

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,10 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * @return TreeBuilder
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('datatables');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('datatables');

--- a/src/DependencyInjection/DataTablesExtension.php
+++ b/src/DependencyInjection/DataTablesExtension.php
@@ -32,7 +32,7 @@ class DataTablesExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/DependencyInjection/Instantiator.php
+++ b/src/DependencyInjection/Instantiator.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 class Instantiator
 {
     /** @var ServiceLocator[] */
-    private $locators;
+    private array $locators;
 
     /**
      * Instantiator constructor.
@@ -53,10 +53,7 @@ class Instantiator
         return $this->getInstance($type, DataTableTypeInterface::class);
     }
 
-    /**
-     * @return mixed
-     */
-    private function getInstance(string $type, string $baseType)
+    private function getInstance(string $type, string $baseType): mixed
     {
         if (isset($this->locators[$baseType]) && $this->locators[$baseType]->has($type)) {
             return $this->locators[$baseType]->get($type);

--- a/src/Exporter/DataTableExporterCollection.php
+++ b/src/Exporter/DataTableExporterCollection.php
@@ -22,16 +22,13 @@ use Omines\DataTablesBundle\Exception\UnknownDataTableExporterException;
  */
 class DataTableExporterCollection
 {
-    /** @var \Traversable The available exporters */
-    private $exporters;
-
     /**
      * DataTableExporterCollection constructor.
+     *
+     * @var \Traversable $exporters The available exporters
      */
-    public function __construct(\Traversable $exporters)
-    {
-        $this->exporters = $exporters;
-    }
+    public function __construct(private \Traversable $exporters)
+    {}
 
     /**
      * Finds a DataTable exporter that matches the given name.

--- a/src/Exporter/DataTableExporterManager.php
+++ b/src/Exporter/DataTableExporterManager.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 namespace Omines\DataTablesBundle\Exporter;
 
 use Omines\DataTablesBundle\DataTable;
-use Omines\DataTablesBundle\Exception\InvalidArgumentException;
 use Omines\DataTablesBundle\Exporter\Event\DataTableExporterResponseEvent;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -28,36 +26,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class DataTableExporterManager
 {
-    /** @var DataTable */
-    private $dataTable;
+    private DataTable $dataTable;
 
-    /** @var DataTableExporterCollection */
-    private $exporterCollection;
-
-    /** @var string */
-    private $exporterName;
-
-    /** @var TranslatorInterface|LegacyTranslatorInterface */
-    private $translator;
+    private string $exporterName;
 
     /**
      * DataTableExporterManager constructor.
-     *
-     * @param TranslatorInterface|LegacyTranslatorInterface $translator
      */
-    public function __construct(DataTableExporterCollection $exporterCollection, $translator)
-    {
-        if (!$translator instanceof TranslatorInterface && !$translator instanceof LegacyTranslatorInterface) {
-            throw new InvalidArgumentException(sprintf('Expected an instance of "Symfony\Contracts\Translation\TranslatorInterface" or "Symfony\Component\Translation\TranslatorInterface". Got "%s" instead.', is_object($translator) ? get_class($translator) : gettype($translator)));
-        }
+    public function __construct(private DataTableExporterCollection $exporterCollection, private TranslatorInterface $translator)
+    {}
 
-        $this->exporterCollection = $exporterCollection;
-        $this->translator = $translator;
-    }
-
-    /**
-     * @return DataTableExporterManager
-     */
     public function setExporterName(string $exporterName): self
     {
         $this->exporterName = $exporterName;
@@ -65,9 +43,6 @@ class DataTableExporterManager
         return $this;
     }
 
-    /**
-     * @return DataTableExporterManager
-     */
     public function setDataTable(DataTable $dataTable): self
     {
         $this->dataTable = $dataTable;

--- a/src/Exporter/Event/DataTableExporterResponseEvent.php
+++ b/src/Exporter/Event/DataTableExporterResponseEvent.php
@@ -22,16 +22,11 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class DataTableExporterResponseEvent extends Event
 {
-    /** @var BinaryFileResponse */
-    private $response;
-
     /**
      * DataTableExporterResponseEvent constructor.
      */
-    public function __construct(BinaryFileResponse $response)
-    {
-        $this->response = $response;
-    }
+    public function __construct(private BinaryFileResponse $response)
+    {}
 
     public function getResponse(): BinaryFileResponse
     {

--- a/src/Exporter/Excel/ExcelExporter.php
+++ b/src/Exporter/Excel/ExcelExporter.php
@@ -64,7 +64,7 @@ class ExcelExporter implements DataTableExporterInterface
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
-    private function autoSizeColumnWidth(Worksheet $sheet)
+    private function autoSizeColumnWidth(Worksheet $sheet): void
     {
         foreach (range(1, Coordinate::columnIndexFromString($sheet->getHighestColumn(1))) as $column) {
             $sheet->getColumnDimension(Coordinate::stringFromColumnIndex($column))->setAutoSize(true);

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -16,16 +16,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractFilter
 {
-    /** @var string */
-    protected $template_html;
+    protected string $template_html;
 
-    /** @var string */
-    protected $template_js;
+    protected string $template_js;
 
-    /** @var string */
-    protected $operator;
+    protected string $operator;
 
-    public function set(array $options)
+    public function set(array $options): void
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
@@ -35,10 +32,7 @@ abstract class AbstractFilter
         }
     }
 
-    /**
-     * @return $this
-     */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         $resolver->setDefaults([
             'template_html' => null,
@@ -49,32 +43,20 @@ abstract class AbstractFilter
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getTemplateHtml()
+    public function getTemplateHtml(): string
     {
         return $this->template_html;
     }
 
-    /**
-     * @return string
-     */
-    public function getTemplateJs()
+    public function getTemplateJs(): string
     {
         return $this->template_js;
     }
 
-    /**
-     * @return string
-     */
-    public function getOperator()
+    public function getOperator(): string
     {
         return $this->operator;
     }
 
-    /**
-     * @param mixed $value
-     */
-    abstract public function isValidValue($value): bool;
+    abstract public function isValidValue(mixed $value): bool;
 }

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -16,16 +16,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChoiceFilter extends AbstractFilter
 {
-    /** @var string */
-    protected $placeholder;
+    protected ?string $placeholder = null;
 
-    /** @var array */
-    protected $choices = [];
+    protected array $choices = [];
 
-    /**
-     * @return $this
-     */
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
 
@@ -42,26 +37,17 @@ class ChoiceFilter extends AbstractFilter
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getPlaceholder()
+    public function getPlaceholder(): ?string
     {
         return $this->placeholder;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getChoices()
+    public function getChoices(): array
     {
         return $this->choices;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isValidValue($value): bool
+    public function isValidValue(mixed $value): bool
     {
         return array_key_exists($value, $this->choices);
     }

--- a/src/Filter/TextFilter.php
+++ b/src/Filter/TextFilter.php
@@ -16,10 +16,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TextFilter extends AbstractFilter
 {
-    /** @var string */
-    protected $placeholder;
+    protected ?string $placeholder = null;
 
-    protected function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
 
@@ -34,18 +33,12 @@ class TextFilter extends AbstractFilter
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getPlaceholder()
+    public function getPlaceholder(): ?string
     {
         return $this->placeholder;
     }
 
-    /**
-     * @param $value
-     */
-    public function isValidValue($value): bool
+    public function isValidValue(mixed $value): bool
     {
         return true;
     }

--- a/src/Twig/DataTablesExtension.php
+++ b/src/Twig/DataTablesExtension.php
@@ -17,21 +17,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DataTablesExtension extends \Twig\Extension\AbstractExtension
 {
-    /** @var TranslatorInterface */
-    protected $translator;
-
     /**
      * DataTablesExtension constructor.
      */
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
+    public function __construct(protected TranslatorInterface $translator)
+    {}
 
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new \Twig\TwigFunction('datatable_settings', function (DataTable $dataTable) {
@@ -47,10 +42,7 @@ class DataTablesExtension extends \Twig\Extension\AbstractExtension
         ];
     }
 
-    /**
-     * @return array
-     */
-    private function getLanguageSettings(DataTable $dataTable)
+    private function getLanguageSettings(DataTable $dataTable): array
     {
         if ($dataTable->isLanguageFromCDN() && null !== ($cdnFile = $this->getCDNLanguageFile())) {
             return ['url' => '//cdn.datatables.net/plug-ins/1.10.15/i18n/' . $cdnFile];
@@ -85,15 +77,13 @@ class DataTablesExtension extends \Twig\Extension\AbstractExtension
 
     /**
      * Returns the name of the extension.
-     *
-     * @return string The extension name
      */
-    public function getName()
+    public function getName(): string
     {
         return 'DataTablesBundle';
     }
 
-    private function getCDNLanguageFile()
+    private function getCDNLanguageFile(): ?string
     {
         $file = $this->translator->trans('file', [], 'DataTablesCDN');
 

--- a/src/Twig/TwigRenderer.php
+++ b/src/Twig/TwigRenderer.php
@@ -24,17 +24,12 @@ use Twig\Environment;
  */
 class TwigRenderer implements DataTableRendererInterface
 {
-    /** @var Twig_Environment */
-    private $twig;
-
     /**
      * DataTableRenderer constructor.
-     *
-     * @param Environment $twig
      */
-    public function __construct(Environment $twig = null)
+    public function __construct(protected ?Environment $twig = null)
     {
-        if (null === ($this->twig = $twig)) {
+        if (null === $this->twig) {
             throw new MissingDependencyException('You must have symfony/twig-bundle installed to use the default Twig based DataTables rendering');
         }
     }

--- a/tests/Fixtures/AppBundle/DataTable/Adapter/CustomORMAdapter.php
+++ b/tests/Fixtures/AppBundle/DataTable/Adapter/CustomORMAdapter.php
@@ -21,7 +21,7 @@ class CustomORMAdapter extends ORMAdapter
 {
     protected $hydrationMode;
 
-    protected function prepareQuery(AdapterQuery $query)
+    protected function prepareQuery(AdapterQuery $query): void
     {
         parent::prepareQuery($query);
         $query->setIdentifierPropertyPath(null);

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -26,8 +26,7 @@ use Tests\Fixtures\AppKernel;
  */
 class FunctionalTest extends WebTestCase
 {
-    /** @var KernelBrowser */
-    private $client;
+    private KernelBrowser $client;
 
     protected function setUp(): void
     {
@@ -66,9 +65,7 @@ class FunctionalTest extends WebTestCase
         $this->assertSame('FirstName94 &lt;img src=&quot;https://symfony.com/images/v5/logos/sf-positive.svg&quot;&gt; LastName94', $sample->fullName);
         $this->assertSame('<a href="http://localhost/employee/95">FirstName94 LastName94</a>', $sample->link);
 
-        // Change when we drop old PHP versions and thus old PHPunit versions
-        $this->assertRegExp('#href="/employee/[0-9]+"#', $sample->buttons);
-        //$this->assertMatchesRegularExpression('#href="/employee/[0-9]+"#', $sample->buttons);
+        $this->assertMatchesRegularExpression('#href="/employee/[0-9]+"#', $sample->buttons);
         $this->assertSame('04-07-2016', $json->data[6]->employedSince);
     }
 

--- a/tests/Unit/Adapter/DoctrineTest.php
+++ b/tests/Unit/Adapter/DoctrineTest.php
@@ -25,6 +25,7 @@ use Omines\DataTablesBundle\Exporter\DataTableExporterManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
+use TypeError;
 
 /**
  * DoctrineTest.
@@ -51,7 +52,9 @@ class DoctrineTest extends TestCase
         $qb = $this->createMock(QueryBuilder::class);
         $qb
             ->method('expr')
-            ->will($this->returnCallback(function () { return new Query\Expr(); }));
+            ->willReturnCallback(function () {
+                return new Query\Expr();
+            });
 
         /* @var QueryBuilder $qb */
         (new SearchCriteriaProvider())->process($qb, $state);
@@ -68,18 +71,6 @@ class DoctrineTest extends TestCase
         (new ORMAdapter());
     }
 
-    public function testInvalidQueryProcessorThrows()
-    {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Provider must be a callable or implement QueryBuilderProcessorInterface');
-
-        (new ORMAdapter($this->createMock(ManagerRegistry::class)))
-            ->configure([
-                'entity' => 'bar',
-                'query' => ['foo'],
-            ]);
-    }
-
     public function testInvalidFieldThrows()
     {
         $this->expectException(InvalidConfigurationException::class);
@@ -91,7 +82,7 @@ class DoctrineTest extends TestCase
         $column->initialize('foo', 0, ['field' => 'invalid'], $this->createMock(DataTable::class));
 
         $mock = new class($this->createMock(ManagerRegistry::class)) extends ORMAdapter {
-            public function foo($query, $column)
+            public function foo($query, $column): ?string
             {
                 return $this->mapPropertyPath($query, $column);
             }

--- a/tests/Unit/ColumnTest.php
+++ b/tests/Unit/ColumnTest.php
@@ -116,7 +116,7 @@ class ColumnTest extends TestCase
         $this->assertSame('684', $column->transform('684'));
 
         $this->assertFalse($column->isRaw());
-        $this->assertTrue($column->isValidForSearch(684));
+        $this->assertTrue($column->isValidForSearch("684"));
         $this->assertFalse($column->isValidForSearch('foo.bar'));
     }
 

--- a/tests/Unit/Exporter/DataTableExporterCollectionTest.php
+++ b/tests/Unit/Exporter/DataTableExporterCollectionTest.php
@@ -29,8 +29,8 @@ class DataTableExporterCollectionTest extends KernelTestCase
 
     public function testUnknownExporter()
     {
-        static::expectException(UnknownDataTableExporterException::class);
-        static::$container
+        $this->expectException(UnknownDataTableExporterException::class);
+        static::getContainer()
             ->get('Omines\DataTablesBundle\Exporter\DataTableExporterCollection')
             ->getByName('unknown-exporter');
     }

--- a/tests/Unit/Exporter/DataTableExporterManagerTest.php
+++ b/tests/Unit/Exporter/DataTableExporterManagerTest.php
@@ -12,12 +12,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Exporter;
 
-use Omines\DataTablesBundle\Exception\InvalidArgumentException;
 use Omines\DataTablesBundle\Exporter\DataTableExporterCollection;
 use Omines\DataTablesBundle\Exporter\DataTableExporterManager;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Translation\DataCollectorTranslator;
-use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -31,13 +28,6 @@ class DataTableExporterManagerTest extends TestCase
     {
         $exporterCollectionMock = $this->createMock(DataTableExporterCollection::class);
 
-        static::expectException(InvalidArgumentException::class);
-        (new DataTableExporterManager($exporterCollectionMock, null));
-
-        static::expectException(InvalidArgumentException::class);
-        (new DataTableExporterManager($exporterCollectionMock, $this->createMock(DataCollectorTranslator::class)));
-
-        static::assertInstanceOf(DataTableExporterManager::class, (new DataTableExporterManager($exporterCollectionMock, $this->createMock(TranslatorInterface::class))));
-        static::assertInstanceOf(DataTableExporterManager::class, (new DataTableExporterManager($exporterCollectionMock, $this->createMock(LegacyTranslatorInterface::class))));
+        static::assertInstanceOf(DataTableExporterManager::class, (new DataTableExporterManager($exporterCollectionMock, $this->createMock(TranslatorInterface::class))));;
     }
 }

--- a/tests/Unit/Exporter/ExcelExporterTest.php
+++ b/tests/Unit/Exporter/ExcelExporterTest.php
@@ -23,14 +23,13 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 class ExcelExporterTest extends KernelTestCase
 {
-    /** @var DataTableExporterCollection */
-    private $exporterCollection;
+    private ?DataTableExporterCollection $exporterCollection;
 
     protected function setUp(): void
     {
         static::bootKernel();
 
-        $this->exporterCollection = static::$container->get('Omines\DataTablesBundle\Exporter\DataTableExporterCollection');
+        $this->exporterCollection = static::getContainer()->get('Omines\DataTablesBundle\Exporter\DataTableExporterCollection');
     }
 
     public function testTag()


### PR DESCRIPTION
Hi, this PR addresses the following points.

* add language feature for php8.0
* add strong types
* adjust tests
* Remove some tests for types that in my eyes are not needed anymore.
* Fix some tests (see static::getContainer() )

Questions:
* isValidForSearch($value) Parameter mixed vs string? I changed it to mixed
* Different return types of configureOptions()  void vs OptionsResolver
  What is the desired behaviour? Should be consistent in my point of view.

There is still one Test not working with symfony6 `ORMAdapterEventsTest->testPreQueryEvent()` but that should be fixed in an other PR