### PR TITLE
fix: deprecation-message for setLength() with null

### DIFF
--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -163,7 +163,7 @@ class DataTableState
 
     public function setLength(?int $length): self
     {
-        if ($length < 1) {
+        if (null !== $length && $length < 1) {
             @trigger_error(sprintf('Calling the "%s::setLength()" method with a length less than 1 is deprecated since version 0.7 of this bundle. If you need to unrestrict the amount of records returned, pass null instead.', self::class), \E_USER_DEPRECATED);
             $length = null;
         }


### PR DESCRIPTION
add check for `null`.
If i run the unittests i got all the deprecation messages. Tests (except for one) do not call setLength() explicity.