### PR TITLE
Docs correction for "Customizing criteria"

### DIFF
--- a/docs/source/index.html.md
+++ b/docs/source/index.html.md
@@ -279,7 +279,7 @@ interaction based on internal changes in this bundle and/or Doctrine ORM.
 ```php?start_inline=1
 $table->createAdapter(ORMAdapter::class, [
     'entity' => Employee::class,
-    'query' => [
+    'criteria' => [
         function (QueryBuilder $builder) {
             $builder->andWhere($builder->expr()->like('c.name', ':test'))->setParameter('test', '%ny 2%');
         },


### PR DESCRIPTION
I believe there is a mistake in the Customizing criteria [code example](https://omines.github.io/datatables-bundle/#customizing-criteria). The key should be `criteria` and not `query`, as in the [test examples](https://github.com/omines/datatables-bundle/blob/master/tests/Fixtures/AppBundle/DataTable/Type/CustomQueryTableType.php).