### PR TITLE
feat: add Searchable EnumColumn and improve SearchCriteriaProvider

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v8
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'

--- a/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
+++ b/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
@@ -59,8 +59,17 @@ class SearchCriteriaProvider implements QueryBuilderProcessorInterface
             $comparisons = $expr->orX();
             foreach ($state->getDataTable()->getColumns() as $column) {
                 if ($column->isGlobalSearchable() && !empty($column->getField()) && $column->isValidForSearch($globalSearch)) {
-                    $comparisons->add(new Comparison($column->getLeftExpr(), $column->getOperator(),
+
+                    if($searchIn = $column->getSearchIn($globalSearch))
+                    {
+                        $comparisons->add($queryBuilder->expr()->in($column->getLeftExpr(), $searchIn));
+                    }
+                    else
+                    {
+                        # default
+                        $comparisons->add(new Comparison($column->getLeftExpr(), $column->getOperator(),
                         $expr->literal($column->getRightExpr($globalSearch))));
+                    }
                 }
             }
             $queryBuilder->andWhere($comparisons);

--- a/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
+++ b/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
@@ -62,7 +62,7 @@ class SearchCriteriaProvider implements QueryBuilderProcessorInterface
 
                     if($searchIn = $column->getSearchIn($globalSearch))
                     {
-                        $comparisons->add($queryBuilder->expr()->in($column->getLeftExpr(), $searchIn));
+                        $comparisons->add($expr->in($column->getLeftExpr(), $searchIn));
                     }
                     else
                     {

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -256,11 +256,13 @@ abstract class AbstractColumn
     public function getSearchIn($value): mixed
     {
         $searchIn = $this->options['searchIn'];
+
         if (null === $searchIn) {
             return null;
         }
+
         if (is_callable($searchIn)) {
-            return call_user_func($searchIn, $value);
+            return call_user_func($searchIn, $this->options, $value);
         }
 
         return $searchIn;

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -120,6 +120,7 @@ abstract class AbstractColumn
                 'leftExpr' => null,
                 'operator' => '=',
                 'rightExpr' => null,
+                'searchIn' => null,
             ])
             ->setAllowedTypes('label', ['null', 'string'])
             ->setAllowedTypes('data', ['null', 'string', 'callable'])
@@ -136,6 +137,7 @@ abstract class AbstractColumn
             ->setAllowedTypes('operator', ['string'])
             ->setAllowedTypes('leftExpr', ['null', 'string', 'callable'])
             ->setAllowedTypes('rightExpr', ['null', 'string', 'callable'])
+            ->setAllowedTypes('searchIn', ['null', 'callable'])
         ;
 
         return $this;
@@ -251,6 +253,19 @@ abstract class AbstractColumn
         return $rightExpr;
     }
 
+    public function getSearchIn($value): mixed
+    {
+        $searchIn = $this->options['searchIn'];
+        if (null === $searchIn) {
+            return null;
+        }
+        if (is_callable($searchIn)) {
+            return call_user_func($searchIn, $value);
+        }
+
+        return $searchIn;
+    }
+    
     /**
      * @return string
      */

--- a/src/Column/EnumColumn.php
+++ b/src/Column/EnumColumn.php
@@ -30,7 +30,7 @@ class EnumColumn extends AbstractColumn
     protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
-
+       
         $resolver->setDefault('searchable', true);
         $resolver->setDefault('visible', true);
 
@@ -44,8 +44,8 @@ class EnumColumn extends AbstractColumn
         $resolver->setDefault('classFunctionSearch', 'label');
         $resolver->setAllowedTypes('classFunctionSearch', ['string', null]);
 
-        $resolver->setDefault('searchIn', function (string $value) {
-            return self::search($this->options["class"], $this->options["classFunctionSearch"], $value);
+        $resolver->setDefault('searchIn', function ($options, string $value) {
+            return $this->search($options["class"], $options["classFunctionSearch"], $value);
         });
 
         return $this;
@@ -56,7 +56,7 @@ class EnumColumn extends AbstractColumn
      * @param class-string $enum
      * @return int[]|string[]
      */
-    public static function search(string $enum, string $classFunctionSearch, string $search): array
+    public function search(string $enum, string $classFunctionSearch, string $search): array
     {
         if(!enum_exists($enum))
         {
@@ -99,6 +99,6 @@ class EnumColumn extends AbstractColumn
 
     public function isValidForSearch(mixed $value): bool
     {
-        return count(self::search($this->options["class"], $this->options["classFunctionSearch"], $value)) > 0;
+        return count($this->search($this->options["class"], $this->options["classFunctionSearch"], $value)) > 0;
     }
 }

--- a/src/Column/EnumColumn.php
+++ b/src/Column/EnumColumn.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Column;
+
+use Omines\DataTablesBundle\Exception\InvalidArgumentException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * EnumColumn
+ * Find search-Values in Enum::labels() or names of an enum and configure the search-query accordingly.
+ *
+ * Use:
+ * $datatable->add('gender', EnumColumn::class, [
+ *       'class' => FooEnum::class,
+ * ])
+ *
+ * Optional: implement label() in your enum.
+ */
+class EnumColumn extends AbstractColumn
+{
+    protected function configureOptions(OptionsResolver $resolver): static
+    {
+        parent::configureOptions($resolver);
+       
+        $resolver->setDefault('searchable', true);
+        $resolver->setDefault('visible', true);
+
+        $resolver->setDefault('class', null);
+        $resolver->setAllowedTypes('class', ['string', 'object', 'mixed']);
+        $resolver->setRequired('class');
+
+        $resolver->setDefault('searchIn', function (string $value) {
+            return self::search($this->options["class"], $value);
+        });
+
+        return $this;
+    }
+
+    /**
+     * @param class-string $enum
+     * @return int[]|string[]
+     */
+    public static function search(string $enum, string $search): array
+    {
+        if(!enum_exists($enum))
+        {
+            throw new InvalidArgumentException(sprintf('%s is not a enum class', $enum));
+        }
+
+        /** @var \UnitEnum $enum */
+        $items = [];
+        foreach($enum::cases() as $case) {
+
+            if(method_exists($enum, 'label'))
+            {
+                if(str_contains($case->label(), $search)) {
+                    $items[] = $case->value;
+                }
+            }
+            else
+            {
+                if(str_contains($case->name, $search)) {
+                    $items[] = $case->value;
+                }
+            }
+        }
+
+        return $items;
+    }
+
+    public function normalize(mixed $value): mixed
+    {
+        if(!$value)
+        {return null;}
+
+        if(method_exists($this->options["class"], 'label'))
+        {
+            return $value->label();
+        }
+
+        return $value->name;
+    }
+
+    public function isValidForSearch(mixed $value): bool
+    {
+        return count(self::search($this->options["class"], $value)) > 0;
+    }
+}


### PR DESCRIPTION
My goal is to have a searchable enums. The enum has a `label()`  function to get the searchable (display) name.
You can search for "Männ" and it filters the dataset correct.
Find search-Values in Enum::labels() or names of an enum and configure the search-query accordingly.

For this reason i need the `IN` Operator, that is not yet possible, if i see this correct.
There are more possible implementation. I want to know how you want this to be handled.
- A more generic search. Instead of `searchIn` an Expression ($queryBuilder->expr())?

Tests will be added after idea is general approved.

Example Enum:

`Enum GenderType: string
{
    case MALE   = 'M';
    case FEMALE = 'F';

    public function label(): string
    {
        return self::getLabel($this);
    }

    public static function getLabel(self $value): string
    {
        return match ($value) {
           // Lang: German
            self::MALE    => 'Männlich',
            self::FEMALE  => 'Weiblich',
        };
    }`


Ideas for improvement: 
- Make it optional sortable by Dispay-Name `label()`
- Test with more use-cases
- Simplify?

WDYT?