### PR TITLE
Pass along query parameters when performing the datatable ajax request

### DIFF
--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -15,7 +15,7 @@
     $.fn.initDataTables = function(config, options) {
 
         //Update default used url, so it reflects the current location (useful on single side apps)
-        $.fn.initDataTables.defaults.url = window.location.origin + window.location.pathname;
+        $.fn.initDataTables.defaults.url = window.location.origin + window.location.pathname + window.location.search;
 
         var root = this,
             config = $.extend({}, $.fn.initDataTables.defaults, config),


### PR DESCRIPTION
I needed a way to limit the dataset based on filters set by my end-user. 

Currently there does not seem to be a simple way to pass along data that is also picked up and send as POST data with the AJAX request.

As a workaround I figured I'd just to set the filters as a get/query parameter but querystring is not being passed to ajax neither. 
Currently the ajax url is constructed as `window.location.origin + window.location.pathname`. 

Adding ` + window.location.search` adds the querystring which then can be picked up in the controller to do with as one wishes (ie. filter the result set).