### PR TITLE
Add return types for DependencyInjection functions to remove deprectations messages

### DIFF
--- a/src/DependencyInjection/Compiler/LocatorRegistrationPass.php
+++ b/src/DependencyInjection/Compiler/LocatorRegistrationPass.php
@@ -33,7 +33,7 @@ class LocatorRegistrationPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $container->getDefinition(Instantiator::class)
             ->setArguments([[

--- a/src/DependencyInjection/DataTablesExtension.php
+++ b/src/DependencyInjection/DataTablesExtension.php
@@ -32,7 +32,7 @@ class DataTablesExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
In symfony 6.3 deprecation messages like :

```php
Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Omines\DataTablesBundle\DependencyInjection\Compiler\LocatorRegistrationPass" now to avoid errors or add an explicit @return annotation to suppress this message.
```

were added, I added the return types for the two classes that generated the deprecation messages.
