### PR TITLE
Fix ordering of columns whose position was changed using colReorder plugin

### DIFF
--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -87,6 +87,17 @@
                             }
                         } else {
                             request._dt = config.name;
+
+                            //Try to resolve the original column index when the column was reordered (using the ColReorder plugin)
+                            //Only do this when _ColReorder_iOrigCol is available
+                            if (settings.aoColumns && settings.aoColumns.length && settings.aoColumns[0]._ColReorder_iOrigCol !== undefined) {
+                                if (request.order && request.order.length) {
+                                    request.order.forEach(function (order) {
+                                        order.column = settings.aoColumns[order.column]._ColReorder_iOrigCol;
+                                    });
+                                }
+                            }
+
                             $.ajax(typeof config.url === 'function' ? config.url(dt) : config.url, {
                                 method: config.method,
                                 data: request


### PR DESCRIPTION
The [colReorder](https://datatables.net/extensions/colreorder/) plugin allows changing the position of columns in the datatable. However, this changes the column index, which does not match the backend index anymore. That caused that the wrong column were ordered in the backend. With this commit, the original index will be put in the request, so always the correct column is ordered.