### PR TITLE
fix: PHP preload error

### DIFF
--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -31,6 +31,9 @@ use Omines\DataTablesBundle\Exception\MissingDependencyException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+// Help opcache.preload discover always-needed symbols
+interface_exists(QueryBuilderProcessorInterface::class);
+
 /**
  * ORMAdapter.
  *


### PR DESCRIPTION
This works for me. It would be great if someone can verify this.
https://github.com/omines/datatables-bundle/issues/288

Idea from https://github.com/symfony/symfony/pull/38533/files