### PR TITLE
Make exporters provide a MIME type

### DIFF
--- a/src/Exporter/Csv/CsvExporter.php
+++ b/src/Exporter/Csv/CsvExporter.php
@@ -40,6 +40,11 @@ class CsvExporter implements DataTableExporterInterface
         return new \SplFileInfo($filePath);
     }
 
+    public function getMimeType(): string
+    {
+        return 'text/csv';
+    }
+
     public function getName(): string
     {
         return 'csv';

--- a/src/Exporter/DataTableExporterInterface.php
+++ b/src/Exporter/DataTableExporterInterface.php
@@ -27,6 +27,11 @@ interface DataTableExporterInterface
     public function export(array $columnNames, \Iterator $data): \SplFileInfo;
 
     /**
+     * The MIME type of the exported file.
+     */
+    public function getMimeType(): string;
+
+    /**
      * A unique name to identify the exporter.
      */
     public function getName(): string;

--- a/src/Exporter/DataTableExporterManager.php
+++ b/src/Exporter/DataTableExporterManager.php
@@ -69,6 +69,7 @@ class DataTableExporterManager
 
         $response = new BinaryFileResponse($file);
         $response->deleteFileAfterSend(true);
+        $response->headers->set('Content-Type', $exporter->getMimeType());
         $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->getFile()->getFilename());
 
         $this->dataTable->getEventDispatcher()->dispatch(new DataTableExporterResponseEvent($response), DataTableExporterEvents::PRE_RESPONSE);

--- a/src/Exporter/Excel/ExcelExporter.php
+++ b/src/Exporter/Excel/ExcelExporter.php
@@ -67,6 +67,11 @@ class ExcelExporter implements DataTableExporterInterface
         }
     }
 
+    public function getMimeType(): string
+    {
+        return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    }
+
     public function getName(): string
     {
         return 'excel';

--- a/tests/Fixtures/AppBundle/DataTable/Exporter/TxtExporter.php
+++ b/tests/Fixtures/AppBundle/DataTable/Exporter/TxtExporter.php
@@ -35,6 +35,11 @@ class TxtExporter implements DataTableExporterInterface
         return new \SplFileInfo($filename);
     }
 
+    public function getMimeType(): string
+    {
+        return 'text/plain';
+    }
+
     public function getName(): string
     {
         return 'txt';


### PR DESCRIPTION
This allows us to set a correct `Content-Type` header in the `BinaryFileResponse`. If we don't do this, the user is required to have automatic MIME type detection available, such as provided by `symfony/mime`.

Closes #316 