### PR TITLE
Add return type in DependencyInjection Configuration function to remove fatal error in PHP8.2/Symfony7

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('datatables');
         $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
In Symfony 7, fatal error is thrown:

```
Fatal error: Declaration of Omines\DataTablesBundle\DependencyInjection\Configuration::getConfigTreeBuilder() must be compatible with Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder(): Symfony\Component\Config\Definition\Builder\TreeBuilder
```

I added the return type for that function