### PR TITLE
Update phpoffice/phpspreadsheet to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "friendsofphp/php-cs-fixer": "^v3.40.0",
         "mongodb/mongodb": "^1.17",
         "ocramius/package-versions": "^2.8",
-        "phpoffice/phpspreadsheet": "^1.29.0",
+        "phpoffice/phpspreadsheet": "^2.0",
         "phpstan/extension-installer": "^1.3.1",
         "phpstan/phpstan": "^1.10.55",
         "phpstan/phpstan-doctrine": "^1.3.54",

--- a/src/Exporter/Excel/ExcelExporter.php
+++ b/src/Exporter/Excel/ExcelExporter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Omines\DataTablesBundle\Exporter\Excel;
 
 use Omines\DataTablesBundle\Exporter\DataTableExporterInterface;
+use PhpOffice\PhpSpreadsheet\Cell\CellAddress;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Helper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
@@ -42,7 +43,7 @@ class ExcelExporter implements DataTableExporterInterface
         foreach ($data as $row) {
             $colIndex = 1;
             foreach ($row as $value) {
-                $sheet->setCellValueByColumnAndRow($colIndex++, $rowIndex, $htmlHelper->toRichTextObject($value));
+                $sheet->getCell(CellAddress::fromColumnAndRow($colIndex++, $rowIndex))->setValue($htmlHelper->toRichTextObject($value ?? ''));
             }
             ++$rowIndex;
         }


### PR DESCRIPTION
 - Update dependency
 - Replace depricated function `setCellValueByColumnAndRow`
 - htmlHelper->toRichTextObject does not support `null` anymore, convert `null` to empty string

Improvement / replacement of https://github.com/omines/datatables-bundle/pull/329