### PR TITLE
test: fix deprecation for doctrine-bundle 2.12

### DIFF
--- a/tests/Fixtures/config.yml
+++ b/tests/Fixtures/config.yml
@@ -48,6 +48,9 @@ doctrine:
             AppBundle:
                 type: attribute
 
+        controller_resolver:
+            auto_mapping: true
+
 twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'


### PR DESCRIPTION
Deprecation Message:
https://github.com/omines/datatables-bundle/actions/runs/8644232823/job/23698941279#step:10:121