### PR TITLE
use Symfony\Component\DependencyInjection\Extension\Extension; instead of deprecated HttpKernel\Extension class

### DIFF
--- a/src/DependencyInjection/DataTablesExtension.php
+++ b/src/DependencyInjection/DataTablesExtension.php
@@ -19,8 +19,8 @@ use Omines\DataTablesBundle\Exporter\DataTableExporterInterface;
 use Omines\DataTablesBundle\Filter\AbstractFilter;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * DataTablesExtension.


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Omines\DataTablesBundle\DependencyInjection\DataTablesExtension".