### PR TITLE
Changes for the OpenSpout Excel export

### DIFF
--- a/tests/Fixtures/routing.yml
+++ b/tests/Fixtures/routing.yml
@@ -44,3 +44,11 @@ exporter:
 exporter_empty_datatable:
     path: /exporter-empty-datatable
     controller: Tests\Fixtures\AppBundle\Controller\ExporterController::exportEmptyDataTableAction
+
+exporter_long_text:
+    path: /exporter-long-text
+    controller: Tests\Fixtures\AppBundle\Controller\ExporterController::exportLongText
+
+exporter_special_chars:
+    path: /exporter-special-chars
+    controller: Tests\Fixtures\AppBundle\Controller\ExporterController::exportSpecialChars


### PR DESCRIPTION
A couple of small changes to the OpenSpout exporter from #332.

* Truncate the value when it is larger than the Excel cell limit
* Do not wrap text
* Decode HTML encoded characters in the value

Alvast bedankt voor het ernaar kijken :)