### PR TITLE
Add raw parameter on AdapterInterface and let OpenSpout exporter use it

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -31,7 +31,7 @@ abstract class AbstractAdapter implements AdapterInterface
         $this->accessor = PropertyAccess::createPropertyAccessor();
     }
 
-    final public function getData(DataTableState $state): ResultSetInterface
+    final public function getData(DataTableState $state, bool $raw = false): ResultSetInterface
     {
         $query = new AdapterQuery($state);
 
@@ -41,7 +41,7 @@ abstract class AbstractAdapter implements AdapterInterface
         $transformer = $state->getDataTable()->getTransformer();
         $identifier = $query->getIdentifierPropertyPath();
 
-        $data = (function () use ($query, $identifier, $transformer, $propertyMap) {
+        $data = (function () use ($query, $identifier, $transformer, $propertyMap, $raw) {
             foreach ($this->getResults($query) as $result) {
                 $row = [];
                 if (!empty($identifier)) {
@@ -51,7 +51,7 @@ abstract class AbstractAdapter implements AdapterInterface
                 /** @var AbstractColumn $column */
                 foreach ($propertyMap as list($column, $mapping)) {
                     $value = ($mapping && $this->accessor->isReadable($result, $mapping)) ? $this->accessor->getValue($result, $mapping) : null;
-                    $row[$column->getName()] = $column->transform($value, $result);
+                    $row[$column->getName()] = $column->transform($value, $result, raw: $raw);
                 }
                 if (null !== $transformer) {
                     $row = call_user_func($transformer, $row, $result);

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -31,5 +31,5 @@ interface AdapterInterface
     /**
      * Processes a datatable's state into a result set fit for further processing.
      */
-    public function getData(DataTableState $state): ResultSetInterface;
+    public function getData(DataTableState $state, bool $raw = false): ResultSetInterface;
 }

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -24,9 +24,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 abstract class AbstractColumn
 {
-    /** @var array<string, OptionsResolver> */
-    private static array $resolversByClass = [];
-
     private string $name;
     private int $index;
     private DataTable $dataTable;
@@ -43,12 +40,9 @@ abstract class AbstractColumn
         $this->index = $index;
         $this->dataTable = $dataTable;
 
-        $class = get_class($this);
-        if (!isset(self::$resolversByClass[$class])) {
-            self::$resolversByClass[$class] = new OptionsResolver();
-            $this->configureOptions(self::$resolversByClass[$class]);
-        }
-        $this->options = self::$resolversByClass[$class]->resolve($options);
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+        $this->options = $resolver->resolve($options);
     }
 
     /**

--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -56,8 +56,9 @@ abstract class AbstractColumn
      *
      * @param mixed $value The single value of the column, if mapping makes it possible to derive one
      * @param mixed $context All relevant data of the entire row
+     * @param bool $raw if true, will not normalize the value to string and will not call `AbstractColumn::render()`
      */
-    public function transform(mixed $value = null, mixed $context = null): mixed
+    public function transform(mixed $value = null, mixed $context = null, bool $raw = false): mixed
     {
         $data = $this->getData();
         if (is_callable($data)) {
@@ -66,7 +67,7 @@ abstract class AbstractColumn
             $value = $data;
         }
 
-        return $this->render($this->normalize($value), $context);
+        return ($raw) ? $value : $this->render($this->normalize($value), $context);
     }
 
     /**

--- a/src/Exporter/AbstractDataTableExporter.php
+++ b/src/Exporter/AbstractDataTableExporter.php
@@ -14,10 +14,18 @@ namespace Omines\DataTablesBundle\Exporter;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * Default implementation for DataTableExporterInterface.
+ */
 abstract class AbstractDataTableExporter implements DataTableExporterInterface
 {
     #[\Override]
     public function configureColumnOptions(OptionsResolver $resolver): void
     {
+    }
+
+    public function supportsRawData(): bool
+    {
+        return false;
     }
 }

--- a/src/Exporter/DataTableExporterInterface.php
+++ b/src/Exporter/DataTableExporterInterface.php
@@ -46,4 +46,16 @@ interface DataTableExporterInterface
      * `exporterOptions` of AbstractColumn.
      */
     public function configureColumnOptions(OptionsResolver $resolver): void;
+
+    /**
+     * Returns whether the exporter supports non-string data.
+     *
+     * The exporter should convert input types to the appropriate output types (e.g. an
+     * int becomes a number type in Excel). Non-supported types should be cast to a
+     * string.
+     *
+     * When this is true, `AbstractColumn::normalize()` and `AbstractColumn::render()`
+     * will not be called.
+     */
+    public function supportsRawData(): bool;
 }

--- a/src/Exporter/DataTableExporterManager.php
+++ b/src/Exporter/DataTableExporterManager.php
@@ -90,7 +90,9 @@ class DataTableExporterManager
      */
     public function getExport(): \SplFileInfo
     {
-        return $this->getExporter()->export($this->getColumnNames(), $this->getAllData(), $this->getColumnOptions());
+        $exporter = $this->getExporter();
+
+        return $exporter->export($this->getColumnNames(), $this->getAllData($exporter->supportsRawData()), $this->getColumnOptions());
     }
 
     /**
@@ -133,11 +135,11 @@ class DataTableExporterManager
      * A Generator is created in order to remove the 'DT_RowId' key
      * which is created by some adapters (e.g. ORMAdapter).
      */
-    private function getAllData(): \Iterator
+    private function getAllData(bool $raw): \Iterator
     {
         $data = $this->dataTable
             ->getAdapter()
-            ->getData($this->dataTable->getState()->setStart(0)->setLength(null))
+            ->getData($this->dataTable->getState()->setStart(0)->setLength(null), raw: $raw)
             ->getData();
 
         foreach ($data as $row) {

--- a/tests/Fixtures/routing.yml
+++ b/tests/Fixtures/routing.yml
@@ -52,3 +52,7 @@ exporter_long_text:
 exporter_special_chars:
     path: /exporter-special-chars
     controller: Tests\Fixtures\AppBundle\Controller\ExporterController::exportSpecialChars
+
+exporter_with_types:
+    path: /exporter-with-types
+    controller: Tests\Fixtures\AppBundle\Controller\ExporterController::exportWithTypes

--- a/tests/Functional/Exporter/Excel/ExcelOpenSpoutExporterTest.php
+++ b/tests/Functional/Exporter/Excel/ExcelOpenSpoutExporterTest.php
@@ -143,4 +143,32 @@ class ExcelOpenSpoutExporterTest extends WebTestCase
         // Value should not contain HTML encoded characters
         static::assertSame('<?xml version="1.0" encoding="UTF-8"?><hello>World</hello>', $sheet->getCell('A2')->getFormattedValue());
     }
+
+    public function testWithTypes(): void
+    {
+        $this->client->request('POST', '/exporter-with-types', [
+            '_dt' => 'dt',
+            '_exporter' => 'excel-openspout',
+        ]);
+
+        /** @var BinaryFileResponse $response */
+        $response = $this->client->getResponse();
+
+        $sheet = IOFactory::load($response->getFile()->getPathname())->getActiveSheet();
+
+        // Test columns
+        static::assertEquals('stringValue', $sheet->getCell('A2')->getValue()->getPlainText());
+        static::assertSame(1, $sheet->getCell('B2')->getValue());
+        static::assertSame(1.1, $sheet->getCell('C2')->getValue());
+        static::assertTrue($sheet->getCell('D2')->getValue());
+
+        // Excel stores dates as a float where the integer part is the number of days since 1900-01-01 and the decimal part is the fraction of the day
+        $expectedDateValue = (new \DateTimeImmutable('2021-01-01 00:00:00'))->diff(new \DateTimeImmutable('1900-01-01 00:00:00'))->days + 2;  // (Have to add 2 due to boundaries)
+        static::assertSame($expectedDateValue, $sheet->getCell('E2')->getValue());
+        static::assertSame(null, $sheet->getCell('F2')->getValue());
+        static::assertSame('toStringValue', $sheet->getCell('G2')->getValue()->getPlainText());
+
+        // This cell contains the exception message thrown when trying to cast an object without a __toString method to a string
+        static::assertSame('Object of class class@anonymous could not be converted to string', $sheet->getCell('H2')->getValue()->getPlainText());
+    }
 }


### PR DESCRIPTION
This prevents calling normalize() and render() on the column during export with the ExcelOpenSpoutExporter.

This allows the exporter to decide how PHP values are represented in the output file.