### PR TITLE
Ignore PHPStan assuming incorrect return type in AutomaticQueryBuilder

### DIFF
--- a/src/Adapter/Doctrine/ORM/AutomaticQueryBuilder.php
+++ b/src/Adapter/Doctrine/ORM/AutomaticQueryBuilder.php
@@ -46,6 +46,7 @@ class AutomaticQueryBuilder implements QueryBuilderProcessorInterface
         $this->metadata = $metadata;
 
         $this->entityName = $this->metadata->getName();
+        /* @phpstan-ignore nullCoalesce.expr, nullsafe.neverNull (the return type may be null in \Doctrine\ORM\Mapping\GetReflectionClassImplementation) */
         $this->entityShortName = mb_strtolower($this->metadata->getReflectionClass()?->getShortName() ?? self::DEFAULT_ALIAS);
     }
 


### PR DESCRIPTION
PHPStan uses the return type specified in the PHPDoc of the interface \Doctrine\Persistence\Mapping\ClassMetadata (which makes sense).

However, the implementation at \Doctrine\ORM\Mapping\ClassMetadata may return null.

I don't know the proper way to fix this so I just ignored it here. (But feel free to reject this PR.)