### PR TITLE
Add `style` and `columnWidth` options to the ExcelOpenSpoutExporter

### DIFF
--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -107,6 +107,7 @@ abstract class AbstractColumn
                 'leftExpr' => null,
                 'operator' => '=',
                 'rightExpr' => null,
+                'exporterOptions' => [],
             ])
             ->setAllowedTypes('label', ['null', 'string'])
             ->setAllowedTypes('data', ['null', 'string', 'callable'])
@@ -123,6 +124,8 @@ abstract class AbstractColumn
             ->setAllowedTypes('operator', ['string'])
             ->setAllowedTypes('leftExpr', ['null', 'string', 'callable'])
             ->setAllowedTypes('rightExpr', ['null', 'string', 'callable'])
+            ->setAllowedTypes('exporterOptions', ['array'])
+            ->setInfo('exporterOptions', 'Specific exporter options can be specified here, where the key is the exporter name and the value is an array of options.')
         ;
 
         return $this;
@@ -244,5 +247,14 @@ abstract class AbstractColumn
     public function isValidForSearch(mixed $value): bool
     {
         return true;
+    }
+
+    /**
+     * @param string $exporterName one of the exporter names as returned by DataTableExporterInterface::getName()
+     * @return array<string, mixed>
+     */
+    public function getExporterOptions(string $exporterName): array
+    {
+        return $this->options['exporterOptions'][$exporterName] ?? [];
     }
 }

--- a/src/Exporter/AbstractDataTableExporter.php
+++ b/src/Exporter/AbstractDataTableExporter.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Exporter;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractDataTableExporter implements DataTableExporterInterface
+{
+    #[\Override]
+    public function configureColumnOptions(OptionsResolver $resolver): void
+    {
+    }
+}

--- a/src/Exporter/Csv/CsvExporter.php
+++ b/src/Exporter/Csv/CsvExporter.php
@@ -12,16 +12,17 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle\Exporter\Csv;
 
-use Omines\DataTablesBundle\Exporter\DataTableExporterInterface;
+use Omines\DataTablesBundle\Exporter\AbstractDataTableExporter;
 
 /**
  * Exports DataTable data to a CSV file.
  *
  * @author Maxime Pinot <maxime.pinot@gbh.fr>
  */
-class CsvExporter implements DataTableExporterInterface
+class CsvExporter extends AbstractDataTableExporter
 {
-    public function export(array $columnNames, \Iterator $data): \SplFileInfo
+    #[\Override]
+    public function export(array $columnNames, \Iterator $data, array $columnOptions): \SplFileInfo
     {
         $filePath = sys_get_temp_dir() . '/' . uniqid('dt') . '.csv';
 

--- a/src/Exporter/DataTableExporterCollection.php
+++ b/src/Exporter/DataTableExporterCollection.php
@@ -35,6 +35,8 @@ class DataTableExporterCollection
 
     /**
      * Finds a DataTable exporter that matches the given name.
+     *
+     * @throws UnknownDataTableExporterException when the exporter with the given name cannot be found
      */
     public function getByName(string $name): DataTableExporterInterface
     {

--- a/src/Exporter/DataTableExporterInterface.php
+++ b/src/Exporter/DataTableExporterInterface.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle\Exporter;
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
 /**
  * Defines a DataTable exporter.
  *
@@ -22,9 +24,10 @@ interface DataTableExporterInterface
     /**
      * Exports the data from the DataTable to a file.
      *
-     * @param mixed[] $columnNames
+     * @param list<string> $columnNames
+     * @param list<array<string, mixed>> $columnOptions the parsed options for each column
      */
-    public function export(array $columnNames, \Iterator $data): \SplFileInfo;
+    public function export(array $columnNames, \Iterator $data, array $columnOptions): \SplFileInfo;
 
     /**
      * The MIME type of the exported file.
@@ -35,4 +38,12 @@ interface DataTableExporterInterface
      * A unique name to identify the exporter.
      */
     public function getName(): string;
+
+    /**
+     * Configures the per-column options available for the exporter.
+     *
+     * The manager will resolve the options using the options array set in
+     * `exporterOptions` of AbstractColumn.
+     */
+    public function configureColumnOptions(OptionsResolver $resolver): void;
 }

--- a/src/Exporter/DataTableExporterManager.php
+++ b/src/Exporter/DataTableExporterManager.php
@@ -18,6 +18,7 @@ use Omines\DataTablesBundle\Exporter\Event\DataTableExporterResponseEvent;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -60,16 +61,15 @@ class DataTableExporterManager
     }
 
     /**
-     * @throws UnknownDataTableExporterException
+     * @throws UnknownDataTableExporterException when the exporter cannot be found
      */
     public function getResponse(): Response
     {
-        $exporter = $this->exporterCollection->getByName($this->exporterName);
-        $file = $exporter->export($this->getColumnNames(), $this->getAllData());
+        $file = $this->getExport();
 
         $response = new BinaryFileResponse($file);
         $response->deleteFileAfterSend(true);
-        $response->headers->set('Content-Type', $exporter->getMimeType());
+        $response->headers->set('Content-Type', $this->getExporter()->getMimeType());
         $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->getFile()->getFilename());
 
         $this->dataTable->getEventDispatcher()->dispatch(new DataTableExporterResponseEvent($response), DataTableExporterEvents::PRE_RESPONSE);
@@ -78,9 +78,43 @@ class DataTableExporterManager
     }
 
     /**
+     * @throws UnknownDataTableExporterException when the exporter cannot be found
+     */
+    public function getExporter(): DataTableExporterInterface
+    {
+        return $this->exporterCollection->getByName($this->exporterName);
+    }
+
+    /**
+     * @throws UnknownDataTableExporterException when the exporter cannot be found
+     */
+    public function getExport(): \SplFileInfo
+    {
+        return $this->getExporter()->export($this->getColumnNames(), $this->getAllData(), $this->getColumnOptions());
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     * @throws UnknownDataTableExporterException when the exporter cannot be found
+     */
+    private function getColumnOptions(): array
+    {
+        $resolver = new OptionsResolver();
+        $this->getExporter()->configureColumnOptions($resolver);
+
+        $options = [];
+        foreach ($this->dataTable->getColumns() as $column) {
+            // For each column, resolve the exporter options set on that column
+            $options[] = $resolver->resolve($column->getExporterOptions($this->exporterName));
+        }
+
+        return $options;
+    }
+
+    /**
      * The translated column names.
      *
-     * @return string[]
+     * @return list<string>
      */
     private function getColumnNames(): array
     {

--- a/src/Exporter/Excel/ExcelExporter.php
+++ b/src/Exporter/Excel/ExcelExporter.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle\Exporter\Excel;
 
-use Omines\DataTablesBundle\Exporter\DataTableExporterInterface;
+use Omines\DataTablesBundle\Exporter\AbstractDataTableExporter;
 use PhpOffice\PhpSpreadsheet\Cell\CellAddress;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Helper;
@@ -25,12 +25,10 @@ use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
  *
  * @author Maxime Pinot <contact@maximepinot.com>
  */
-class ExcelExporter implements DataTableExporterInterface
+class ExcelExporter extends AbstractDataTableExporter
 {
-    /**
-     * @param mixed[] $columnNames
-     */
-    public function export(array $columnNames, \Iterator $data): \SplFileInfo
+    #[\Override]
+    public function export(array $columnNames, \Iterator $data, array $columnOptions): \SplFileInfo
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getSheet(0);

--- a/tests/Fixtures/AppBundle/Controller/ExporterController.php
+++ b/tests/Fixtures/AppBundle/Controller/ExporterController.php
@@ -19,6 +19,7 @@ use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTableFactory;
 use Omines\DataTablesBundle\Exporter\DataTableExporterEvents;
 use Omines\DataTablesBundle\Exporter\Event\DataTableExporterResponseEvent;
+use OpenSpout\Common\Entity\Style\Style;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,8 +39,22 @@ class ExporterController extends AbstractController
                 'render' => function (string $value, Person $context) {
                     return '<a href="http://example.org">' . $value . '</a>';
                 },
+                // We also test the exporter specific options
+                'exporterOptions' => [
+                    'excel-openspout' => [
+                        'style' => (new Style())->setFontItalic(),
+                        'columnWidth' => 20,
+                    ],
+                ],
             ])
-            ->add('lastName', TextColumn::class)
+            ->add('lastName', TextColumn::class, [
+                'exporterOptions' => [
+                    'excel-openspout' => [
+                        'style' => fn (mixed $value) => (new Style())->setFontBold(),  // We can also use a callable
+                        'columnWidth' => 30,
+                    ],
+                ],
+            ])
             ->createAdapter(ORMAdapter::class, [
                 'entity' => Person::class,
                 'query' => function (QueryBuilder $builder) {

--- a/tests/Fixtures/AppBundle/DataTable/Exporter/TxtExporter.php
+++ b/tests/Fixtures/AppBundle/DataTable/Exporter/TxtExporter.php
@@ -12,14 +12,15 @@ declare(strict_types=1);
 
 namespace Tests\Fixtures\AppBundle\DataTable\Exporter;
 
-use Omines\DataTablesBundle\Exporter\DataTableExporterInterface;
+use Omines\DataTablesBundle\Exporter\AbstractDataTableExporter;
 
 /**
  * @author Maxime Pinot <contact@maximepinot.com>
  */
-class TxtExporter implements DataTableExporterInterface
+class TxtExporter extends AbstractDataTableExporter
 {
-    public function export(array $columnNames, \Iterator $data): \SplFileInfo
+    #[\Override]
+    public function export(array $columnNames, \Iterator $data, array $columnOptions): \SplFileInfo
     {
         $filename = sys_get_temp_dir() . '/dt.txt';
         $handle = fopen($filename, 'w');

--- a/tests/Functional/Exporter/Excel/ExcelOpenSpoutExporterTest.php
+++ b/tests/Functional/Exporter/Excel/ExcelOpenSpoutExporterTest.php
@@ -54,6 +54,19 @@ class ExcelOpenSpoutExporterTest extends WebTestCase
 
         static::assertSame('FirstName4', $sheet->getCell('A6')->getFormattedValue());
         static::assertSame('LastName4', $sheet->getCell('B6')->getFormattedValue());
+
+        // Test exporter options
+
+        // - First column should be italic
+        static::assertTrue($sheet->getCell('A2')->getAppliedStyle()->getFont()->getItalic());
+        static::assertFalse($sheet->getCell('A2')->getAppliedStyle()->getFont()->getBold());
+        // - Second column should be bold
+        static::assertFalse($sheet->getCell('B2')->getAppliedStyle()->getFont()->getItalic());
+        static::assertTrue($sheet->getCell('B2')->getAppliedStyle()->getFont()->getBold());
+        // - First column should have a width of 20
+        static::assertSame(20.0, $sheet->getColumnDimension('A')->getWidth());
+        // - Second column should have a width of 30
+        static::assertSame(30.0, $sheet->getColumnDimension('B')->getWidth());
     }
 
     public function testEmptyDataTable(): void


### PR DESCRIPTION
This PR is a suggestion for making the Excel export output a little bit configurable, using custom column styles and widths. This way, we can have a native Excel currency format for the output columns in the Excel file.

Thanks for your helpful e-mail last week 😃. And I fully agree that a currency column will probably never be able to satisfy everyone's specific requirements.

See commit message for details.