### PR TITLE
Fixes and changes for column filters

### DIFF
--- a/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
+++ b/src/Adapter/Doctrine/ORM/SearchCriteriaProvider.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle\Adapter\Doctrine\ORM;
 
+use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
 use Omines\DataTablesBundle\Column\AbstractColumn;
@@ -43,8 +44,7 @@ class SearchCriteriaProvider implements QueryBuilderProcessorInterface
                         continue;
                     }
                 }
-                $search = $queryBuilder->expr()->literal($search);
-                $queryBuilder->andWhere(new Comparison($column->getField(), $column->getOperator(), $search));
+                $queryBuilder->andWhere($this->getSearchComparison($column, $search));
             }
         }
     }
@@ -56,11 +56,19 @@ class SearchCriteriaProvider implements QueryBuilderProcessorInterface
             $comparisons = $expr->orX();
             foreach ($state->getDataTable()->getColumns() as $column) {
                 if ($column->isGlobalSearchable() && !empty($column->getField()) && $column->isValidForSearch($globalSearch)) {
-                    $comparisons->add(new Comparison($column->getLeftExpr(), $column->getOperator(),
-                        $expr->literal($column->getRightExpr($globalSearch))));
+                    $comparisons->add($this->getSearchComparison($column, $globalSearch));
                 }
             }
             $queryBuilder->andWhere($comparisons);
         }
+    }
+
+    private function getSearchComparison(AbstractColumn $column, string $search): Comparison
+    {
+        return new Comparison(
+            $column->getLeftExpr(),
+            $column->getOperator(),
+            (new Expr())->literal($column->getRightExpr($search)),
+        );
     }
 }

--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -104,7 +104,10 @@ final class DataTableState
             $column = $this->dataTable->getColumn((int) $key);
             $value = $this->isInitial ? $search : $search['search']['value'] ?? '';
 
-            if ($column->isSearchable() && ('' !== mb_trim($value))) {
+            // We do not check for $column->isSearchable() here, because at this point the
+            // field option may not have been set yet. This makes the check for isSearchable()
+            // unreliable.
+            if ('' !== mb_trim($value)) {
                 $this->setColumnSearch($column, $value);
             }
         }
@@ -204,11 +207,13 @@ final class DataTableState
     /**
      * Returns an array of column-level searches.
      *
+     * @param bool $onlySearchable if true, only returns columns for which isSearchable() is true
      * @return SearchColumn[]
      */
-    public function getSearchColumns(): array
+    public function getSearchColumns(bool $onlySearchable = true): array
     {
-        return $this->searchColumns;
+        // `searchColumns` may include columns that are not searchable, so we filter them out here.
+        return array_filter($this->searchColumns, fn ($searchInfo) => !$onlySearchable || $searchInfo['column']->isSearchable());
     }
 
     public function setColumnSearch(AbstractColumn $column, string $search, bool $isRegex = false): static

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -18,7 +18,6 @@ abstract class AbstractFilter
 {
     protected string $template_html;
     protected string $template_js;
-    protected string $operator;
 
     /**
      * @param array<string, mixed> $options
@@ -38,7 +37,6 @@ abstract class AbstractFilter
         $resolver->setDefaults([
             'template_html' => null,
             'template_js' => null,
-            'operator' => 'CONTAINS',
         ]);
 
         return $this;
@@ -52,11 +50,6 @@ abstract class AbstractFilter
     public function getTemplateJs(): string
     {
         return $this->template_js;
-    }
-
-    public function getOperator(): string
-    {
-        return $this->operator;
     }
 
     abstract public function isValidValue(mixed $value): bool;

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -16,27 +16,34 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractFilter
 {
-    protected string $template_html;
-    protected string $template_js;
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $options = [];
+
+    public function __construct()
+    {
+        // Initialize the options with the default values set on the OptionsResolver
+        $this->set([]);
+    }
 
     /**
      * @param array<string, mixed> $options
      */
-    public function set(array $options): void
+    public function set(array $options): static
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
+        $this->options = $resolver->resolve($options);
 
-        foreach ($resolver->resolve($options) as $key => $value) {
-            $this->$key = $value;
-        }
+        return $this;
     }
 
     protected function configureOptions(OptionsResolver $resolver): static
     {
-        $resolver->setDefaults([
-            'template_html' => null,
-            'template_js' => null,
+        $resolver->setRequired([
+            'template_html',
+            'template_js',
         ]);
 
         return $this;
@@ -44,12 +51,12 @@ abstract class AbstractFilter
 
     public function getTemplateHtml(): string
     {
-        return $this->template_html;
+        return $this->options['template_html'];
     }
 
     public function getTemplateJs(): string
     {
-        return $this->template_js;
+        return $this->options['template_js'];
     }
 
     abstract public function isValidValue(mixed $value): bool;

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -16,11 +16,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChoiceFilter extends AbstractFilter
 {
-    protected ?string $placeholder = null;
-
-    /** @var array<string, string> */
-    protected array $choices = [];
-
     protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
@@ -40,7 +35,7 @@ class ChoiceFilter extends AbstractFilter
 
     public function getPlaceholder(): ?string
     {
-        return $this->placeholder;
+        return $this->options['placeholder'];
     }
 
     /**
@@ -48,11 +43,11 @@ class ChoiceFilter extends AbstractFilter
      */
     public function getChoices(): array
     {
-        return $this->choices;
+        return $this->options['choices'];
     }
 
     public function isValidValue(mixed $value): bool
     {
-        return array_key_exists($value, $this->choices);
+        return array_key_exists($value, $this->getChoices());
     }
 }

--- a/src/Filter/TextFilter.php
+++ b/src/Filter/TextFilter.php
@@ -16,8 +16,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TextFilter extends AbstractFilter
 {
-    protected ?string $placeholder = null;
-
     protected function configureOptions(OptionsResolver $resolver): static
     {
         parent::configureOptions($resolver);
@@ -35,7 +33,7 @@ class TextFilter extends AbstractFilter
 
     public function getPlaceholder(): ?string
     {
-        return $this->placeholder;
+        return $this->options['placeholder'];
     }
 
     public function isValidValue(mixed $value): bool

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -100,6 +100,17 @@ class FunctionalTest extends WebTestCase
         $this->assertCount(2, $json->data);
         $this->assertStringStartsWith('Company ', $json->data[0]->company);
         $this->assertSame('LastName24 (Company 4)', $json->data[0]->fullName);
+
+        // A column search should be based on substring matching by default (same as global
+        // search). Not on exact matching.
+        $json = $this->callDataTableUrl('/service?_dt=persons&draw=2&order[0][column]=2&order[0][dir]=desc&columns[1][search][value]=name24');
+        $this->assertCount(1, $json->data);
+        $this->assertSame('LastName24 (Company 4)', $json->data[0]->fullName);
+
+        // Search for `LastName1` in the first name column should return no results. This
+        // tests that the column search only applies to the specified column.
+        $json = $this->callDataTableUrl('/service?_dt=persons&draw=2&order[0][column]=2&order[0][dir]=desc&columns[1][search][value]=LastName1');
+        $this->assertCount(0, $json->data);
     }
 
     public function testCustomDataTable(): void

--- a/tests/Unit/Adapter/ORMAdapterTest.php
+++ b/tests/Unit/Adapter/ORMAdapterTest.php
@@ -19,7 +19,9 @@ use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Omines\DataTablesBundle\DataTableFactory;
 use Omines\DataTablesBundle\DataTableState;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Tests\Fixtures\AppBundle\DataTable\Type\GroupedTableType;
+use Tests\Fixtures\AppBundle\DataTable\Type\ServicePersonTableType;
 
 class ORMAdapterTest extends KernelTestCase
 {
@@ -41,6 +43,32 @@ class ORMAdapterTest extends KernelTestCase
         /** @var ORMAdapter $adapter */
         $adapter = $datatable->getAdapter();
         $data = $adapter->getData(new DataTableState($datatable));
+    }
+
+    /**
+     * Tests that column searches are applied when `field` is set by ORMAdapter.
+     *
+     * When `field` and `searchable` are not set manually, isSearchable() will only
+     * return true after the `field` option is set by ORMAdapter. This tests that the
+     * column search still is applied correctly.
+     */
+    public function testColumnSearch(): void
+    {
+        $datatable = $this->factory->createFromType(ServicePersonTableType::class)
+            ->setMethod(Request::METHOD_GET);
+        $datatable->handleRequest(Request::create('/?_dt=' . $datatable->getName() . '&columns[1][search][value]=John'));
+
+        // At this point, $searchColumns is empty because isSearchable() returns false due
+        // to `field` not being set yet. Ideally it should contain the search value.
+        $searchColumns = $datatable->getState()->getSearchColumns();
+        $this->assertCount(0, $searchColumns);
+
+        // After calling getData(), the column search should be correctly returned.
+        $datatable->getAdapter()->getData($datatable->getState());
+
+        $searchColumns = $datatable->getState()->getSearchColumns();
+        $this->assertCount(1, $searchColumns);
+        $this->assertSame('John', $searchColumns['firstName']['search']);
     }
 
     public function testORMAdapterQueryEvent(): void

--- a/tests/Unit/DataTableTest.php
+++ b/tests/Unit/DataTableTest.php
@@ -98,7 +98,7 @@ class DataTableTest extends TestCase
         $this->assertSame(10, $state->getLength());
         $this->assertSame('foo', $state->getGlobalSearch());
         $this->assertCount(2, $state->getOrderBy());
-        $this->assertSame('bar', $state->getSearchColumns()['foo']['search']);
+        $this->assertSame('bar', $state->getSearchColumns(onlySearchable: false)['foo']['search']);
 
         // Test boundaries
         $state->setStart(-1);
@@ -109,6 +109,28 @@ class DataTableTest extends TestCase
 
         $column = $datatable->getColumn(0);
         $this->assertSame($state, $column->getState());
+    }
+
+    /**
+     * Tests that getSearchColumns only returns columns for which `isSearchable()` is true.
+     */
+    public function testDataTableStateSearchColumns(): void
+    {
+        $datatable = $this
+            ->createMockDataTable()
+            ->add('foo', TextColumn::class, ['searchable' => true])
+            ->add('bar', TextColumn::class, ['searchable' => false])
+            ->setMethod(Request::METHOD_GET)
+        ;
+        $datatable->handleRequest(Request::create('/?_dt=' . $datatable->getName()));
+
+        $state = $datatable->getState();
+        $state->setColumnSearch($datatable->getColumn(0), 'foo');
+        $state->setColumnSearch($datatable->getColumn(1), 'bar');
+
+        $searchColumns = $state->getSearchColumns();
+        $this->assertCount(1, $searchColumns);
+        $this->assertSame('foo', $searchColumns['foo']['search']);
     }
 
     public function testPostMethod(): void

--- a/tests/Unit/FilterTest.php
+++ b/tests/Unit/FilterTest.php
@@ -33,7 +33,6 @@ class FilterTest extends TestCase
 
         $filter->set([
             'choices' => ['foo' => 'bar', 'bar' => 'baz'],
-            'operator' => 'bar',
             'placeholder' => 'foobar',
             'template_html' => 'foobar.html',
         ]);
@@ -44,7 +43,6 @@ class FilterTest extends TestCase
         $this->assertSame('foobar', $filter->getPlaceholder());
         $this->assertSame('foobar.html', $filter->getTemplateHtml());
         $this->assertSame('@DataTables/Filter/select.js.twig', $filter->getTemplateJs());
-        $this->assertSame('bar', $filter->getOperator());
     }
 
     public function testTextFilter(): void
@@ -57,12 +55,10 @@ class FilterTest extends TestCase
 
         $filter->set([
             'template_js' => 'foobar.js',
-            'operator' => 'foo',
             'placeholder' => 'baz',
         ]);
         $this->assertSame('@DataTables/Filter/text.html.twig', $filter->getTemplateHtml());
         $this->assertSame('foobar.js', $filter->getTemplateJs());
-        $this->assertSame('foo', $filter->getOperator());
         $this->assertSame('baz', $filter->getPlaceholder());
     }
 }


### PR DESCRIPTION
The column filters (TextFilter/ChoiceFilter/..) use exact matching for filtering. However, I would expect such filters to have substring matching by default, like the following DataTables example: https://datatables.net/extensions/fixedcolumns/examples/styling/col_filter.html

This PR changes the search behaviour for column filters to be the same as for global seach, using the options `leftExpr`, `operator` and `rightExpr` from AbstractColumn.

We might want to make this behaviour overridable. For the ChoiceFilter it would make sense to use exact matching. We could add an option to AbstractFilter to override the search settings. I will add this if you agree with this approach.

Other changes:
    
* The `operator` option in AbstractFilter was used nowhere, so I removed it.
* There was a bug where the column search is not set correctly on DataTableState. In `DataTableState::handleSearch()` the function setColumnSearch is only called when isSearchable is true. But isSearchable only becomes true after the field option is set. For the ORMAdapter this only happens in `ORMAdapter::prepareQuery()`, which is *after* the call to `handleSearch`. I fixed this by always storing the column search and doing the check for isSearchable later, in the getter. This is not the most elegant solution.

See the individual commits for more details.