### PR TITLE
Change AbstractAdapter to use iterator instead of array

### DIFF
--- a/src/Adapter/ArrayAdapter.php
+++ b/src/Adapter/ArrayAdapter.php
@@ -69,7 +69,7 @@ class ArrayAdapter implements AdapterInterface
         $length = $state->getLength() ?? 0;
         $page = $length > 0 ? array_slice($data, $state->getStart(), $state->getLength()) : $data;
 
-        return new ArrayResultSet($page, count($this->data), count($data));
+        return new ResultSet(new \ArrayIterator($page), count($this->data), count($data));
     }
 
     /**

--- a/src/Adapter/ResultSet.php
+++ b/src/Adapter/ResultSet.php
@@ -13,27 +13,22 @@ declare(strict_types=1);
 namespace Omines\DataTablesBundle\Adapter;
 
 /**
- * ArrayResultSet.
- *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  *
- * @phpstan-type Row array<string, mixed>
+ * @phpstan-type Row array<(int|string), mixed>
+ *
+ * (Note: when using ArrayAdapter, the Row keys may be integers instead of strings.)
  */
-class ArrayResultSet implements ResultSetInterface
+class ResultSet implements ResultSetInterface
 {
-    /** @var Row[] */
-    private array $data;
-    private int $totalRows;
-    private int $totalFilteredRows;
-
     /**
-     * @param Row[] $data
+     * @param \Iterator<Row> $data
      */
-    public function __construct(array $data, ?int $totalRows = null, ?int $totalFilteredRows = null)
-    {
-        $this->data = $data;
-        $this->totalRows = $totalRows ?? count($data);
-        $this->totalFilteredRows = $totalFilteredRows ?? $this->totalRows;
+    public function __construct(
+        private readonly \Iterator $data,
+        private readonly int $totalRows,
+        private readonly int $totalFilteredRows,
+    ) {
     }
 
     public function getTotalRecords(): int
@@ -48,6 +43,6 @@ class ArrayResultSet implements ResultSetInterface
 
     public function getData(): \Iterator
     {
-        return new \ArrayIterator($this->data);
+        return $this->data;
     }
 }

--- a/tests/Unit/Adapter/ORMAdapterTest.php
+++ b/tests/Unit/Adapter/ORMAdapterTest.php
@@ -41,6 +41,7 @@ class ORMAdapterTest extends KernelTestCase
         /** @var ORMAdapter $adapter */
         $adapter = $datatable->getAdapter();
         $data = $adapter->getData(new DataTableState($datatable));
+        iterator_to_array($data->getData());  // Evaluate the iterator to trigger the exception
     }
 
     public function testORMAdapterQueryEvent(): void


### PR DESCRIPTION
We are using asynchronous server-side exports with this library. When a user clicks on export it dispatches a message and lets a worker configure the datatable and run the export. I use a custom adapter to make this work.

I cannot use the built-in adapters when I want to show progress, because AbstractAdapter::getData loads everything in an array and is final.

Would you be interested in changing the AbstractAdapter so that it uses a generator instead of using an iterator made from an array, as in this PR? By using a generator in the ResultSet like this, I can iterate over getData() in the worker and easily update the progress bar during exports.

I don't think this should cause issues, unless users of the library expect a new iterator each time they call getData(). But that would be abusing the ResultSetInterface API because the interface never specifies that implementations should always return a new iterator.

If you have a better solution to this problem, let me know.