### PR TITLE
Add pre and post response events

### DIFF
--- a/docs/source/index.html.md
+++ b/docs/source/index.html.md
@@ -545,6 +545,39 @@ Of course you can modify the base type to fit the controller's specific needs be
 `handleRequest`. Secondly, the `createDataTableFromType` function accepts an array as a second
 argument which is passed to the type class for parametrized instantiation.
 
+# Events
+
+A few events are available that allow you to hook into the DataTables lifecycle. These are dispatched
+by the `DataTable` instance, and can be listened to by adding event listeners to the table.
+
+## DataTableEvents::PRE_RESPONSE
+
+This event is dispatched just before the response is created, allowing you to modify the table
+one last time while the table state is already known. This could, for instance, be useful for
+adding or removing columns when in the server-side exporting context.
+
+```php?start_inline=1
+$table->addEventListener(DataTableEvents::PRE_RESPONSE, function (DataTablePreResponseEvent $event) {
+    $table = $event->getTable();
+
+    $table
+        ->add('extraColumn', TextColumn::class)
+        ->remove('obsoleteColumn')
+    ;
+});
+```
+
+## DataTableEvents::POST_RESPONSE
+
+This event is dispatched just after the response is created but before it is returned to the client.
+This is useful for logging, or other post-processing tasks.
+
+```php?start_inline=1
+$table->addEventListener(DataTableEvents::POST_RESPONSE, function (DataTablePreResponseEvent $event) use ($logger) {
+    $logger->info('Table rendered', ['table' => $event->getTable()]);
+});
+```
+
 # Javascript
 
 ```javascript

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -16,6 +16,8 @@ use Omines\DataTablesBundle\Adapter\AdapterInterface;
 use Omines\DataTablesBundle\Adapter\ResultSetInterface;
 use Omines\DataTablesBundle\Column\AbstractColumn;
 use Omines\DataTablesBundle\DependencyInjection\Instantiator;
+use Omines\DataTablesBundle\Event\DataTablePostResponseEvent;
+use Omines\DataTablesBundle\Event\DataTablePreResponseEvent;
 use Omines\DataTablesBundle\Exception\InvalidArgumentException;
 use Omines\DataTablesBundle\Exception\InvalidConfigurationException;
 use Omines\DataTablesBundle\Exception\InvalidStateException;
@@ -119,6 +121,28 @@ class DataTable
 
         $this->columns[] = $column;
         $this->columnsByName[$name] = $column;
+
+        return $this;
+    }
+
+    public function remove(string $name): static
+    {
+        if (!isset($this->columnsByName[$name])) {
+            throw new InvalidArgumentException(sprintf("There is no column with name '%s'", $name));
+        }
+
+        $column = $this->columnsByName[$name];
+        unset($this->columnsByName[$name]);
+        $index = array_search($column, $this->columns, true);
+        unset($this->columns[$index]);
+
+        return $this;
+    }
+
+    public function clearColumns(): static
+    {
+        $this->columns = [];
+        $this->columnsByName = [];
 
         return $this;
     }
@@ -263,14 +287,19 @@ class DataTable
 
     public function getResponse(): Response
     {
+        $this->eventDispatcher->dispatch(new DataTablePreResponseEvent($this), DataTableEvents::PRE_RESPONSE);
+
         $state = $this->getState();
 
         // Server side export
         if (null !== $state->getExporterName()) {
-            return $this->exporterManager
+            $response = $this->exporterManager
                 ->setDataTable($this)
                 ->setExporterName($state->getExporterName())
                 ->getResponse();
+            $this->eventDispatcher->dispatch(new DataTablePostResponseEvent($this), DataTableEvents::POST_RESPONSE);
+
+            return $response;
         }
 
         $resultSet = $this->getResultSet();
@@ -284,6 +313,8 @@ class DataTable
             $response['options'] = $this->getInitialResponse();
             $response['template'] = $this->renderer->renderDataTable($this, $this->template, $this->templateParams);
         }
+
+        $this->eventDispatcher->dispatch(new DataTablePostResponseEvent($this), DataTableEvents::POST_RESPONSE);
 
         return new JsonResponse($response);
     }

--- a/src/DataTableEvents.php
+++ b/src/DataTableEvents.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle;
+
+/**
+ * Available events.
+ *
+ * @author Jeroen van den Broek <jeroen.van.den.broek@omines.com>
+ */
+final class DataTableEvents
+{
+    /**
+     * The PRE_RESPONSE event is dispatched right before the response
+     * is generated to allow any last-minute changes based on the table state.
+     *
+     * @Event("Omines\DataTablesBundle\Event\DataTablePreResponseEvent")
+     */
+    public const PRE_RESPONSE = 'omines_datatables.pre_response';
+
+    /**
+     * The POST_RESPONSE event is dispatched right after the response
+     * is generated but before it is returned.
+     *
+     * @Event("Omines\DataTablesBundle\Event\DataTablePostResponseEvent")
+     */
+    public const POST_RESPONSE = 'omines_datatables.post_response';
+}

--- a/src/Event/DataTableEvent.php
+++ b/src/Event/DataTableEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Event;
+
+use Omines\DataTablesBundle\DataTable;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * DataTableEvent.
+ *
+ * @author Jeroen van den Broek <jeroen.van.den.broek@omines.com>
+ */
+abstract class DataTableEvent extends Event
+{
+    /**
+     * DataTableEvent constructor.
+     */
+    public function __construct(
+        protected readonly DataTable $table,
+    ) {
+    }
+
+    public function getTable(): DataTable
+    {
+        return $this->table;
+    }
+}

--- a/src/Event/DataTablePostResponseEvent.php
+++ b/src/Event/DataTablePostResponseEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Event;
+
+/**
+ * DataTablePostResponseEvent.
+ *
+ * @author Jeroen van den Broek <jeroen.van.den.broek@omines.com>
+ */
+class DataTablePostResponseEvent extends DataTableResponseEvent
+{
+}

--- a/src/Event/DataTablePreResponseEvent.php
+++ b/src/Event/DataTablePreResponseEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Event;
+
+/**
+ * DataTablePreResponseEvent.
+ *
+ * @author Jeroen van den Broek <jeroen.van.den.broek@omines.com>
+ */
+class DataTablePreResponseEvent extends DataTableResponseEvent
+{
+}

--- a/src/Event/DataTableResponseEvent.php
+++ b/src/Event/DataTableResponseEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * DataTableResponseEvent.
+ *
+ * @author Jeroen van den Broek <jeroen.van.den.broek@omines.com>
+ */
+abstract class DataTableResponseEvent extends DataTableEvent
+{
+    public function getResponse(): Response
+    {
+        return $this->table->getResponse();
+    }
+}

--- a/tests/Fixtures/AppBundle/DataTable/Type/RegularPersonTableType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/RegularPersonTableType.php
@@ -16,7 +16,9 @@ use Omines\DataTablesBundle\Adapter\ArrayAdapter;
 use Omines\DataTablesBundle\Column\DateTimeColumn;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
+use Omines\DataTablesBundle\DataTableEvents;
 use Omines\DataTablesBundle\DataTableTypeInterface;
+use Omines\DataTablesBundle\Event\DataTablePreResponseEvent;
 
 /**
  * RegularPersonTableType.
@@ -36,6 +38,7 @@ class RegularPersonTableType implements DataTableTypeInterface
                 },
                 'format' => 'd-m-Y',
             ])
+            ->add('dummy', TextColumn::class, ['data' => fn () => ''])
             ->createAdapter(ArrayAdapter::class, [
                 ['firstName' => 'Donald', 'lastName' => 'Trump'],
                 ['firstName' => 'Barack', 'lastName' => 'Obama'],
@@ -48,6 +51,16 @@ class RegularPersonTableType implements DataTableTypeInterface
                 $row['lastName'] = mb_strtoupper($row['lastName']);
 
                 return $row;
+            })
+            ->addEventListener(DataTableEvents::PRE_RESPONSE, function (DataTablePreResponseEvent $event) {
+                $table = $event->getTable();
+
+                $table
+                    ->add('email', TextColumn::class, [
+                        'data' => fn ($context) => mb_strtolower($context['lastName']) . '@example.org',
+                    ])
+                    ->remove('dummy')
+                ;
             })
         ;
     }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -81,6 +81,8 @@ class FunctionalTest extends WebTestCase
         $this->assertSame('George W.', $json->data[0]->firstName);
         $this->assertSame('BUSH', $json->data[0]->lastName);
         $this->assertSame('01-01-2017', $json->data[0]->lastActivity);
+        $this->assertSame('bush@example.org', $json->data[0]->email);
+        $this->assertObjectNotHasProperty('dummy', $json->data[0]);
 
         $json = $this->callDataTableUrl('/type?_dt=persons&draw=1&search[value]=Bush');
 


### PR DESCRIPTION
It can be useful to plug into the table rendering process right before or right after rendering the response. One specific use case would be to detect the state of the datatable and to add or remove columns based on that state before the final response is generated. Another use case would be to add logging before or after the response is generated.

I included these two use cases as examples in the extension I wrote for the documentation.

Please note that I conformed the way I dispatch events to the way it is done in the rest of the project to make sure I don't cause any compatibility issues with older Symfony versions.