### PR TITLE
Make the raw export opt-in

### DIFF
--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -61,7 +61,7 @@ abstract class AbstractColumn
             $value = $data;
         }
 
-        return ($raw) ? $value : $this->render($this->normalize($value), $context);
+        return ($raw && $this->options['enableRawExport']) ? $value : $this->render($this->normalize($value), $context);
     }
 
     /**
@@ -102,6 +102,7 @@ abstract class AbstractColumn
                 'leftExpr' => null,
                 'operator' => '=',
                 'rightExpr' => null,
+                'enableRawExport' => false,
                 'exporterOptions' => [],
             ])
             ->setAllowedTypes('label', ['null', 'string'])
@@ -119,7 +120,9 @@ abstract class AbstractColumn
             ->setAllowedTypes('operator', ['string'])
             ->setAllowedTypes('leftExpr', ['null', 'string', 'callable'])
             ->setAllowedTypes('rightExpr', ['null', 'string', 'callable'])
+            ->setAllowedTypes('enableRawExport', ['bool'])
             ->setAllowedTypes('exporterOptions', ['array'])
+            ->setInfo('enableRawExport', 'When true, skips normalize() and render() during raw transforms.')
             ->setInfo('exporterOptions', 'Specific exporter options can be specified here, where the key is the exporter name and the value is an array of options.')
         ;
 

--- a/tests/Fixtures/AppBundle/Controller/ExporterController.php
+++ b/tests/Fixtures/AppBundle/Controller/ExporterController.php
@@ -140,19 +140,29 @@ class ExporterController extends AbstractController
 
     public function exportWithTypes(Request $request, DataTableFactory $factory): Response
     {
+        $enableRawExport = ['enableRawExport' => true];
         $table = $factory
             ->create()
             ->add('stringColumn', TextColumn::class)
-            ->add('integerColumn', NumberColumn::class)
-            ->add('floatColumn', NumberColumn::class)
-            ->add('boolColumn', BoolColumn::class)
-            ->add('dateTimeColumn', DateTimeColumn::class)
-            ->add('nullColumn', TextColumn::class)
-            ->add('typeWithToStringColumn', TextColumn::class)
-            ->add('typeWithoutToStringColumn', TextColumn::class)
+            ->add('stringColumnWithTags', TextColumn::class, ['raw' => true])
+            ->add('integerColumn', NumberColumn::class, $enableRawExport)
+            ->add('floatColumn', NumberColumn::class, $enableRawExport)
+            ->add('boolColumn', BoolColumn::class, $enableRawExport)
+            ->add('dateTimeColumn', DateTimeColumn::class, $enableRawExport)
+            ->add('nullColumn', TextColumn::class, $enableRawExport)
+            ->add('typeWithToStringColumn', TextColumn::class, $enableRawExport)
+            ->add('typeWithoutToStringColumn', TextColumn::class, $enableRawExport)
+            ->add('stringColumnWithoutStripTags', TextColumn::class, [
+                'exporterOptions' => [
+                    'excel-openspout' => [
+                        'stripTags' => false,
+                    ],
+                ],
+            ])
             ->createAdapter(ArrayAdapter::class, [
                 [
                     'stringColumn' => 'stringValue',
+                    'stringColumnWithTags' => '<a href="https://example.org">link with special character &lt;</a>',
                     'integerColumn' => 1,
                     'floatColumn' => 1.1,
                     'boolColumn' => true,
@@ -165,6 +175,7 @@ class ExporterController extends AbstractController
                         }
                     },
                     'typeWithoutToStringColumn' => new class {},
+                    'stringColumnWithoutStripTags' => '<a href="https://example.org">link with special character &lt;</a>',
                 ],
             ])
         ;

--- a/tests/Functional/Exporter/Excel/ExcelOpenSpoutExporterTest.php
+++ b/tests/Functional/Exporter/Excel/ExcelOpenSpoutExporterTest.php
@@ -158,17 +158,20 @@ class ExcelOpenSpoutExporterTest extends WebTestCase
 
         // Test columns
         static::assertEquals('stringValue', $sheet->getCell('A2')->getValue()->getPlainText());
-        static::assertSame(1, $sheet->getCell('B2')->getValue());
-        static::assertSame(1.1, $sheet->getCell('C2')->getValue());
-        static::assertTrue($sheet->getCell('D2')->getValue());
+        static::assertEquals('link with special character <', $sheet->getCell('B2')->getValue()->getPlainText());
+        static::assertSame(1, $sheet->getCell('C2')->getValue());
+        static::assertSame(1.1, $sheet->getCell('D2')->getValue());
+        static::assertTrue($sheet->getCell('E2')->getValue());
 
         // Excel stores dates as a float where the integer part is the number of days since 1900-01-01 and the decimal part is the fraction of the day
         $expectedDateValue = (new \DateTimeImmutable('2021-01-01 00:00:00'))->diff(new \DateTimeImmutable('1900-01-01 00:00:00'))->days + 2;  // (Have to add 2 due to boundaries)
-        static::assertSame($expectedDateValue, $sheet->getCell('E2')->getValue());
-        static::assertSame(null, $sheet->getCell('F2')->getValue());
-        static::assertSame('toStringValue', $sheet->getCell('G2')->getValue()->getPlainText());
+        static::assertSame($expectedDateValue, $sheet->getCell('F2')->getValue());
+        static::assertSame(null, $sheet->getCell('G2')->getValue());
+        static::assertSame('toStringValue', $sheet->getCell('H2')->getValue()->getPlainText());
 
         // This cell contains the exception message thrown when trying to cast an object without a __toString method to a string
-        static::assertSame('Object of class class@anonymous could not be converted to string', $sheet->getCell('H2')->getValue()->getPlainText());
+        static::assertSame('Object of class class@anonymous could not be converted to string', $sheet->getCell('I2')->getValue()->getPlainText());
+
+        static::assertEquals('&lt;a href=&quot;https://example.org&quot;&gt;link with special character &amp;lt;&lt;/a&gt;', $sheet->getCell('J2')->getValue()->getPlainText());
     }
 }


### PR DESCRIPTION
The new change to skip AbstractColumn::transform() during export seems to be a quite intrusive backwards-incompatible change, because we use the `render` option quite a lot construct the column value (even though we should probably use `data` for that).

So I suggest to make it an opt-in feature.

I just made it an extra column option here.