### PR TITLE
Allow DateTimeColumns to handle different timezones

### DIFF
--- a/src/Column/DateTimeColumn.php
+++ b/src/Column/DateTimeColumn.php
@@ -44,7 +44,8 @@ class DateTimeColumn extends AbstractColumn
         }
 
         if ($this->options['modelTimezone'] !== $this->options['viewTimezone']) {
-            $value = $value->setTimezone($this->options['viewTimezone']);       // Assignment is required, without it the timezone changes but the times stay the same
+            // Assign a new value because just changing the timezone does not change the visual representation of the time
+            $value = \DateTime::createFromInterface($value)->setTimezone($this->options['viewTimezone']);
         }
 
         return $value->format($this->options['format']);


### PR DESCRIPTION
Allow different timezones to be set for the model value and the view that is shown. Useful when you for instance store datetimes as UTC but want to display them for another timezone.

Not passing any timezones will make the column function exactly as it did before, passing either of `modelTimezone` or `viewTimezone` (or both) will convert between the two. If no value is passed for either timezone, the default timezone is used by default. You can pass null, a string or a `\DateTimeZone` object as a value..