### PR TITLE
Enforce sort direction in dql. Do not allowing ordering when disabled.

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -174,7 +174,10 @@ class DataTable
         if (!$column instanceof AbstractColumn) {
             $column = is_int($column) ? $this->getColumn($column) : $this->getColumnByName((string) $column);
         }
-        $this->options['order'][] = [$column->getIndex(), $direction];
+        if (false !== $this->getOption('ordering')) {
+            $direction = self::SORT_ASCENDING === $direction ? self::SORT_ASCENDING : self::SORT_DESCENDING;
+            $this->options['order'][] = [$column->getIndex(), $direction];
+        }
 
         return $this;
     }

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -175,7 +175,7 @@ class DataTable
             $column = is_int($column) ? $this->getColumn($column) : $this->getColumnByName((string) $column);
         }
         if (false !== $this->getOption('ordering')) {
-            $direction = self::SORT_ASCENDING === $direction ? self::SORT_ASCENDING : self::SORT_DESCENDING;
+            $direction = self::SORT_ASCENDING === mb_strtolower($direction) ? self::SORT_ASCENDING : self::SORT_DESCENDING;
             $this->options['order'][] = [$column->getIndex(), $direction];
         }
 

--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -181,7 +181,10 @@ final class DataTableState
 
     public function addOrderBy(AbstractColumn $column, string $direction = DataTable::SORT_ASCENDING): static
     {
-        $this->orderBy[] = [$column, $direction];
+        if (false !== $this->dataTable->getOption('ordering')) {
+            $direction = DataTable::SORT_ASCENDING === $direction ? DataTable::SORT_ASCENDING : DataTable::SORT_DESCENDING;
+            $this->orderBy[] = [$column, $direction];
+        }
 
         return $this;
     }
@@ -199,7 +202,10 @@ final class DataTableState
      */
     public function setOrderBy(array $orderBy = []): static
     {
-        $this->orderBy = $orderBy;
+        $this->orderBy = [];
+        foreach ($orderBy as [$column, $direction]) {
+            $this->addOrderBy($column, $direction);
+        }
 
         return $this;
     }

--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -182,7 +182,7 @@ final class DataTableState
     public function addOrderBy(AbstractColumn $column, string $direction = DataTable::SORT_ASCENDING): static
     {
         if (false !== $this->dataTable->getOption('ordering')) {
-            $direction = DataTable::SORT_ASCENDING === $direction ? DataTable::SORT_ASCENDING : DataTable::SORT_DESCENDING;
+            $direction = DataTable::SORT_ASCENDING === mb_strtolower($direction) ? DataTable::SORT_ASCENDING : DataTable::SORT_DESCENDING;
             $this->orderBy[] = [$column, $direction];
         }
 


### PR DESCRIPTION
closes #388 