### PR TITLE
Option to add row count lazily

### DIFF
--- a/docs/source/index.html.md
+++ b/docs/source/index.html.md
@@ -318,6 +318,32 @@ $table->addEventListener(ORMAdapterEvents::PRE_QUERY, function(ORMAdapterQueryEv
 The `PRE_QUERY` event is dispatched after the QueryBuilder built the Query
 and before the iteration starts. It can be useful to configure the cache.
 
+### Lazy count loading
+
+```php?start_inline=1
+$table->createAdapter(ORMAdapter::class, [
+    'entity' => Employee::class,
+    'lazy_total_count' => true,
+    'lazy_filtered_count' => true,
+]);
+```
+On large tables, `COUNT` queries can be a significant performance bottleneck. The lazy count options
+let you defer these expensive queries so the table renders immediately with its row data, while the
+record counts (used for the info text and pagination) are fetched in a separate background request.
+
+Option | Type | Default | Description
+------ | ---- | ------- | -----------
+lazy_total_count | bool | `false` | Defer the total record count query.
+lazy_filtered_count | bool | `false` | Defer the filtered record count query.
+
+When either option is enabled, the initial response is sent without waiting for the count query.
+The bundled JavaScript automatically fires a lightweight follow-up request to retrieve the real
+counts and updates the table's info text and pagination once they arrive. During this brief
+loading period the info text is hidden to avoid displaying placeholder values.
+
+You can enable one or both options depending on your use case. For tables where the unfiltered
+count is fast but filtering is slow, `lazy_filtered_count` alone may be sufficient.
+
 ## Elastica
 
 ```php?start_inline=1

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -64,7 +64,7 @@ abstract class AbstractAdapter implements AdapterInterface
             throw new \LogicException('Adapter did not set row counts');
         }
 
-        return new ResultSet($data, $query->getTotalRows(), $query->getFilteredRows());
+        return new ResultSet($data, $query->getTotalRows(), $query->getFilteredRows(), $query->isCountDeferred());
     }
 
     /**

--- a/src/Adapter/AdapterQuery.php
+++ b/src/Adapter/AdapterQuery.php
@@ -25,6 +25,7 @@ class AdapterQuery
     private ?int $totalRows;
     private ?int $filteredRows;
     private ?string $identifierPropertyPath = null;
+    private bool $countDeferred = false;
 
     /** @var array<string, mixed> */
     private array $data;
@@ -70,6 +71,18 @@ class AdapterQuery
     public function setIdentifierPropertyPath(?string $identifierPropertyPath): static
     {
         $this->identifierPropertyPath = $identifierPropertyPath;
+
+        return $this;
+    }
+
+    public function isCountDeferred(): bool
+    {
+        return $this->countDeferred;
+    }
+
+    public function setCountDeferred(bool $countDeferred): static
+    {
+        $this->countDeferred = $countDeferred;
 
         return $this;
     }

--- a/src/Adapter/Doctrine/ORMAdapter.php
+++ b/src/Adapter/Doctrine/ORMAdapter.php
@@ -45,7 +45,7 @@ interface_exists(QueryBuilderProcessorInterface::class);
  * @author Robbert Beesems <robbert.beesems@omines.com>
  *
  * @phpstan-type HydrationMode AbstractQuery::HYDRATE_*
- * @phpstan-type ORMOptions array{entity: class-string, hydrate: HydrationMode, query: QueryBuilderProcessorInterface[], criteria: QueryBuilderProcessorInterface[]}
+ * @phpstan-type ORMOptions array{entity: class-string, hydrate: HydrationMode, query: QueryBuilderProcessorInterface[], criteria: QueryBuilderProcessorInterface[], lazy_total_count: bool, lazy_filtered_count: bool}
  */
 class ORMAdapter extends AbstractAdapter
 {
@@ -63,6 +63,10 @@ class ORMAdapter extends AbstractAdapter
 
     /** @var QueryBuilderProcessorInterface[] */
     protected array $criteriaProcessors = [];
+
+    private bool $lazyTotalCount = false;
+
+    private bool $lazyFilteredCount = false;
 
     public function __construct(?ManagerRegistry $registry = null)
     {
@@ -109,11 +113,24 @@ class ORMAdapter extends AbstractAdapter
         /** @var Query\Expr\From $fromClause */
         $fromClause = $builder->getDQLPart('from')[0];
         $identifier = "{$fromClause->getAlias()}.{$this->metadata->getSingleIdentifierFieldName()}";
-        $query->setTotalRows($this->getCount($builder, $identifier));
+        $isCountRequest = $state->getDataTable()->isCountRequest();
+        if ($this->lazyTotalCount && !$isCountRequest) {
+            $query->setTotalRows(0);
+        } else {
+            $query->setTotalRows($this->getCount($builder, $identifier));
+        }
 
         // Get record count after filtering
         $this->buildCriteria($builder, $state);
-        $query->setFilteredRows($this->getCount($builder, $identifier));
+        if ($this->lazyFilteredCount && !$isCountRequest) {
+            $query->setFilteredRows(0);
+        } else {
+            $query->setFilteredRows($this->getCount($builder, $identifier));
+        }
+
+        if (!$isCountRequest && ($this->lazyTotalCount || $this->lazyFilteredCount)) {
+            $query->setCountDeferred(true);
+        }
 
         // Perform mapping of all referred fields and implied fields
         $aliases = $this->getAliases($query);
@@ -292,12 +309,16 @@ class ORMAdapter extends AbstractAdapter
                 'criteria' => function (Options $options) {
                     return [new SearchCriteriaProvider()];
                 },
+                'lazy_total_count' => false,
+                'lazy_filtered_count' => false,
             ])
             ->setRequired('entity')
             ->setAllowedTypes('entity', ['string'])
             ->setAllowedTypes('hydrate', 'int')
             ->setAllowedTypes('query', [QueryBuilderProcessorInterface::class, 'array', 'callable'])
             ->setAllowedTypes('criteria', [QueryBuilderProcessorInterface::class, 'array', 'callable', 'null'])
+            ->setAllowedTypes('lazy_total_count', 'bool')
+            ->setAllowedTypes('lazy_filtered_count', 'bool')
             ->setNormalizer('query', $providerNormalizer)
             ->setNormalizer('criteria', $providerNormalizer)
         ;
@@ -323,6 +344,8 @@ class ORMAdapter extends AbstractAdapter
         $this->hydrationMode = $options['hydrate'];
         $this->queryBuilderProcessors = $options['query'];
         $this->criteriaProcessors = $options['criteria'];
+        $this->lazyTotalCount = $options['lazy_total_count'];
+        $this->lazyFilteredCount = $options['lazy_filtered_count'];
     }
 
     private function normalizeProcessor(callable|QueryBuilderProcessorInterface $provider): QueryBuilderProcessorInterface

--- a/src/Adapter/ResultSet.php
+++ b/src/Adapter/ResultSet.php
@@ -28,6 +28,7 @@ class ResultSet implements ResultSetInterface
         private readonly \Iterator $data,
         private readonly int $totalRows,
         private readonly int $totalFilteredRows,
+        private readonly bool $countDeferred = false,
     ) {
     }
 
@@ -39,6 +40,11 @@ class ResultSet implements ResultSetInterface
     public function getTotalDisplayRecords(): int
     {
         return $this->totalFilteredRows;
+    }
+
+    public function isCountDeferred(): bool
+    {
+        return $this->countDeferred;
     }
 
     public function getData(): \Iterator

--- a/src/Adapter/ResultSetInterface.php
+++ b/src/Adapter/ResultSetInterface.php
@@ -30,6 +30,11 @@ interface ResultSetInterface
     public function getTotalDisplayRecords(): int;
 
     /**
+     * Returns whether the count was deferred and should be fetched separately.
+     */
+    public function isCountDeferred(): bool;
+
+    /**
      * Returns the raw data in the result set.
      */
     public function getData(): \Iterator;

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -92,6 +92,13 @@ class DataTable
     private ?DataTableState $state = null;
     private Instantiator $instantiator;
 
+    private bool $countRequest = false;
+
+    public function isCountRequest(): bool
+    {
+        return $this->countRequest;
+    }
+
     /**
      * @param array<string, mixed> $options
      */
@@ -279,6 +286,9 @@ class DataTable
             if (null === $this->state) {
                 $this->state = DataTableState::fromDefaults($this);
             }
+
+            $this->countRequest = (bool) $parameters->get('_dt_count', false);
+
             $this->state->applyParameters($parameters);
         }
 
@@ -303,12 +313,27 @@ class DataTable
         }
 
         $resultSet = $this->getResultSet();
+
+        if ($this->countRequest) {
+            $response = [
+                'draw' => $state->getDraw(),
+                'recordsTotal' => $resultSet->getTotalRecords(),
+                'recordsFiltered' => $resultSet->getTotalDisplayRecords(),
+            ];
+
+            $this->eventDispatcher->dispatch(new DataTablePostResponseEvent($this), DataTableEvents::POST_RESPONSE);
+
+            return new JsonResponse($response);
+        }
         $response = [
             'draw' => $state->getDraw(),
             'recordsTotal' => $resultSet->getTotalRecords(),
             'recordsFiltered' => $resultSet->getTotalDisplayRecords(),
             'data' => iterator_to_array($resultSet->getData()),
         ];
+        if ($resultSet->isCountDeferred()) {
+            $response['countDeferred'] = true;
+        }
         if ($state->isInitial()) {
             $response['options'] = $this->getInitialResponse();
             $response['template'] = $this->renderer->renderDataTable($this, $this->template, $this->templateParams);

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -325,11 +325,12 @@ class DataTable
 
             return new JsonResponse($response);
         }
+        $data = iterator_to_array($resultSet->getData());
         $response = [
             'draw' => $state->getDraw(),
             'recordsTotal' => $resultSet->getTotalRecords(),
             'recordsFiltered' => $resultSet->getTotalDisplayRecords(),
-            'data' => iterator_to_array($resultSet->getData()),
+            'data' => $data,
         ];
         if ($resultSet->isCountDeferred()) {
             $response['countDeferred'] = true;

--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -68,12 +68,39 @@
             }).done(function(data) {
                 var baseState;
 
+                function requestDeferredCount(dt, request, settings, originalResponse) {
+                    if (!originalResponse.countDeferred) {
+                        return;
+                    }
+
+                    var countRequest = $.extend(true, {}, request);
+                    countRequest._dt = config.name;
+                    countRequest._dt_count = 1;
+
+                    $.ajax(typeof config.url === 'function' ? config.url(dt) : config.url, {
+                        method: config.method,
+                        data: countRequest
+                    }).done(function(countData) {
+                        var api = new $.fn.dataTable.Api(settings);
+
+                        if (countData.draw !== api.ajax.params().draw) {
+                            return;
+                        }
+
+                        settings._iRecordsTotal = countData.recordsTotal;
+                        settings._iRecordsDisplay = countData.recordsFiltered;
+
+                        api.draw(false);
+                    });
+                }
+
                 // Merge all options from different sources together and add the Ajax loader
                 var dtOpts = $.extend({}, data.options, typeof config.options === 'function' ? {} : config.options, options, persistOptions, {
                     ajax: function (request, drawCallback, settings) {
                         if (data) {
                             data.draw = request.draw;
                             drawCallback(data);
+                            requestDeferredCount(null, request, settings, data);
                             data = null;
                             if (Object.keys(state).length) {
                                 var api = new $.fn.dataTable.Api( settings );
@@ -92,7 +119,8 @@
                                 data: request
                             }).done(function(data) {
                                 drawCallback(data);
-                            })
+                                requestDeferredCount(dt, request, settings, data);
+                            });
                         }
                     }
                 });

--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -68,10 +68,13 @@
             }).done(function(data) {
                 var baseState;
 
-                function requestDeferredCount(dt, request, settings, originalResponse) {
+                function requestDeferredCount(dt, request, settings, originalResponse, drawCallback) {
                     if (!originalResponse.countDeferred) {
                         return;
                     }
+
+                    // Hide the info element while the real counts are loading
+                    $(settings.nTableWrapper).find('.dataTables_info').css('visibility', 'hidden');
 
                     var countRequest = $.extend(true, {}, request);
                     countRequest._dt = config.name;
@@ -87,10 +90,14 @@
                             return;
                         }
 
-                        settings._iRecordsTotal = countData.recordsTotal;
-                        settings._iRecordsDisplay = countData.recordsFiltered;
-
-                        api.draw(false);
+                        // Update counts in the original response and re-draw the table
+                        // so DataTables fully recalculates info text and pagination
+                        originalResponse.recordsTotal = countData.recordsTotal;
+                        originalResponse.recordsFiltered = countData.recordsFiltered;
+                        delete originalResponse.countDeferred;
+                        drawCallback(originalResponse);
+                    }).always(function() {
+                        $(settings.nTableWrapper).find('.dataTables_info').css('visibility', '');
                     });
                 }
 
@@ -100,7 +107,7 @@
                         if (data) {
                             data.draw = request.draw;
                             drawCallback(data);
-                            requestDeferredCount(null, request, settings, data);
+                            requestDeferredCount(null, request, settings, data, drawCallback);
                             data = null;
                             if (Object.keys(state).length) {
                                 var api = new $.fn.dataTable.Api( settings );
@@ -119,7 +126,7 @@
                                 data: request
                             }).done(function(data) {
                                 drawCallback(data);
-                                requestDeferredCount(dt, request, settings, data);
+                                requestDeferredCount(dt, request, settings, data, drawCallback);
                             });
                         }
                     }

--- a/tests/Unit/Adapter/AdapterQueryTest.php
+++ b/tests/Unit/Adapter/AdapterQueryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter;
+
+use Omines\DataTablesBundle\Adapter\AdapterQuery;
+use Omines\DataTablesBundle\DataTable;
+use Omines\DataTablesBundle\DataTableState;
+use PHPUnit\Framework\TestCase;
+
+class AdapterQueryTest extends TestCase
+{
+    public function testCountDeferredDefaultsToFalse(): void
+    {
+        $state = new DataTableState($this->createMock(DataTable::class));
+        $query = new AdapterQuery($state);
+
+        $this->assertFalse($query->isCountDeferred());
+    }
+
+    public function testCountDeferredCanBeSet(): void
+    {
+        $state = new DataTableState($this->createMock(DataTable::class));
+        $query = new AdapterQuery($state);
+
+        $result = $query->setCountDeferred(true);
+
+        $this->assertTrue($query->isCountDeferred());
+        $this->assertSame($query, $result);
+    }
+}

--- a/tests/Unit/Adapter/ORMAdapterLazyCountTest.php
+++ b/tests/Unit/Adapter/ORMAdapterLazyCountTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter;
+
+use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
+use Omines\DataTablesBundle\Column\TextColumn;
+use Omines\DataTablesBundle\DataTableFactory;
+use Omines\DataTablesBundle\DataTableState;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\Fixtures\AppBundle\Entity\Employee;
+
+class ORMAdapterLazyCountTest extends KernelTestCase
+{
+    private DataTableFactory $factory;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->factory = $kernel->getContainer()->get(DataTableFactory::class);
+    }
+
+    public function testLazyTotalCountReturnsDeferredResultSet(): void
+    {
+        $datatable = $this->factory->create()
+            ->add('firstName', TextColumn::class)
+            ->add('lastName', TextColumn::class)
+            ->createAdapter(ORMAdapter::class, [
+                'entity' => Employee::class,
+                'lazy_total_count' => true,
+            ]);
+
+        $state = new DataTableState($datatable);
+        $resultSet = $datatable->getAdapter()->getData($state);
+
+        $this->assertTrue($resultSet->isCountDeferred());
+        $this->assertSame(0, $resultSet->getTotalRecords());
+        $this->assertGreaterThan(0, $resultSet->getTotalDisplayRecords());
+    }
+
+    public function testLazyFilteredCountReturnsDeferredResultSet(): void
+    {
+        $datatable = $this->factory->create()
+            ->add('firstName', TextColumn::class)
+            ->add('lastName', TextColumn::class)
+            ->createAdapter(ORMAdapter::class, [
+                'entity' => Employee::class,
+                'lazy_filtered_count' => true,
+            ]);
+
+        $state = new DataTableState($datatable);
+        $resultSet = $datatable->getAdapter()->getData($state);
+
+        $this->assertTrue($resultSet->isCountDeferred());
+        $this->assertGreaterThan(0, $resultSet->getTotalRecords());
+        $this->assertSame(0, $resultSet->getTotalDisplayRecords());
+    }
+
+    public function testBothLazyCountsReturnsDeferredResultSet(): void
+    {
+        $datatable = $this->factory->create()
+            ->add('firstName', TextColumn::class)
+            ->add('lastName', TextColumn::class)
+            ->createAdapter(ORMAdapter::class, [
+                'entity' => Employee::class,
+                'lazy_total_count' => true,
+                'lazy_filtered_count' => true,
+            ]);
+
+        $state = new DataTableState($datatable);
+        $resultSet = $datatable->getAdapter()->getData($state);
+
+        $this->assertTrue($resultSet->isCountDeferred());
+        $this->assertSame(0, $resultSet->getTotalRecords());
+        $this->assertSame(0, $resultSet->getTotalDisplayRecords());
+    }
+
+    public function testWithoutLazyCountsReturnsNonDeferredResultSet(): void
+    {
+        $datatable = $this->factory->create()
+            ->add('firstName', TextColumn::class)
+            ->add('lastName', TextColumn::class)
+            ->createAdapter(ORMAdapter::class, [
+                'entity' => Employee::class,
+            ]);
+
+        $state = new DataTableState($datatable);
+        $resultSet = $datatable->getAdapter()->getData($state);
+
+        $this->assertFalse($resultSet->isCountDeferred());
+        $this->assertGreaterThan(0, $resultSet->getTotalRecords());
+        $this->assertGreaterThan(0, $resultSet->getTotalDisplayRecords());
+    }
+
+    public function testCountRequestComputesActualCounts(): void
+    {
+        $datatable = $this->factory->create()
+            ->add('firstName', TextColumn::class)
+            ->add('lastName', TextColumn::class)
+            ->createAdapter(ORMAdapter::class, [
+                'entity' => Employee::class,
+                'lazy_total_count' => true,
+                'lazy_filtered_count' => true,
+            ]);
+
+        // Simulate a count request
+        $datatable->handleRequest(Request::create('/foo', Request::METHOD_POST, [
+            '_dt' => $datatable->getName(),
+            '_dt_count' => 1,
+            'draw' => 1,
+        ]));
+
+        $this->assertTrue($datatable->isCountRequest());
+
+        $resultSet = $datatable->getAdapter()->getData($datatable->getState());
+
+        // On a count request, actual counts should be computed even with lazy options
+        $this->assertFalse($resultSet->isCountDeferred());
+        $this->assertGreaterThan(0, $resultSet->getTotalRecords());
+        $this->assertGreaterThan(0, $resultSet->getTotalDisplayRecords());
+    }
+}

--- a/tests/Unit/Adapter/ResultSetTest.php
+++ b/tests/Unit/Adapter/ResultSetTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter;
+
+use Omines\DataTablesBundle\Adapter\ResultSet;
+use PHPUnit\Framework\TestCase;
+
+class ResultSetTest extends TestCase
+{
+    public function testCountDeferredDefaultsToFalse(): void
+    {
+        $resultSet = new ResultSet(new \EmptyIterator(), 10, 5);
+
+        $this->assertFalse($resultSet->isCountDeferred());
+        $this->assertSame(10, $resultSet->getTotalRecords());
+        $this->assertSame(5, $resultSet->getTotalDisplayRecords());
+    }
+
+    public function testCountDeferredCanBeEnabled(): void
+    {
+        $resultSet = new ResultSet(new \EmptyIterator(), 0, 0, true);
+
+        $this->assertTrue($resultSet->isCountDeferred());
+        $this->assertSame(0, $resultSet->getTotalRecords());
+        $this->assertSame(0, $resultSet->getTotalDisplayRecords());
+    }
+}

--- a/tests/Unit/DataTableTest.php
+++ b/tests/Unit/DataTableTest.php
@@ -344,6 +344,74 @@ class DataTableTest extends TestCase
             ->createFromType('foo');
     }
 
+    public function testCountRequestFlag(): void
+    {
+        $datatable = $this->createMockDataTable()
+            ->add('foo', TextColumn::class);
+
+        $this->assertFalse($datatable->isCountRequest());
+
+        $datatable->handleRequest(Request::create('/foo', Request::METHOD_POST, [
+            '_dt' => $datatable->getName(),
+            '_dt_count' => 1,
+            'draw' => 1,
+        ]));
+
+        $this->assertTrue($datatable->isCountRequest());
+    }
+
+    public function testCountRequestFlagDefaultsToFalse(): void
+    {
+        $datatable = $this->createMockDataTable()
+            ->add('foo', TextColumn::class);
+
+        $datatable->handleRequest(Request::create('/foo', Request::METHOD_POST, [
+            '_dt' => $datatable->getName(),
+            'draw' => 1,
+        ]));
+
+        $this->assertFalse($datatable->isCountRequest());
+    }
+
+    public function testCountRequestReturnsMinimalResponse(): void
+    {
+        $datatable = $this->createMockDataTable()
+            ->add('foo', TextColumn::class)
+            ->createAdapter(ArrayAdapter::class);
+
+        $datatable->handleRequest(Request::create('/foo', Request::METHOD_POST, [
+            '_dt' => $datatable->getName(),
+            '_dt_count' => 1,
+            'draw' => 42,
+        ]));
+
+        $response = $datatable->getResponse();
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame(42, $data['draw']);
+        $this->assertArrayHasKey('recordsTotal', $data);
+        $this->assertArrayHasKey('recordsFiltered', $data);
+        $this->assertArrayNotHasKey('data', $data);
+    }
+
+    public function testNormalResponseDoesNotIncludeCountDeferred(): void
+    {
+        $datatable = $this->createMockDataTable()
+            ->add('foo', TextColumn::class)
+            ->createAdapter(ArrayAdapter::class);
+
+        $datatable->handleRequest(Request::create('/foo', Request::METHOD_POST, [
+            '_dt' => $datatable->getName(),
+            'draw' => 1,
+        ]));
+
+        $response = $datatable->getResponse();
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertArrayNotHasKey('countDeferred', $data);
+        $this->assertArrayHasKey('data', $data);
+    }
+
     private function createMockDataTable(array $options = []): DataTable
     {
         return new DataTable($this->createMock(EventDispatcher::class), $this->createMock(DataTableExporterManager::class), $options);


### PR DESCRIPTION
Hi everyone! For our project, we have a huge table displayed using datatables-bundle. Because of the forced 'count' queries, the request becomes extremely slow. Therefore, I have implemented the option to lazily count the amount of rows displayed.

Current flow in `ORMAdapter.php`:

1. Build query
2. Count ALL results
3. Apply filters
4. Count filtered results
5. Fetch 50 rows
6. Return everything

Mostly step 2, but also step 4 make the request much longer when big tables are being used. Therefore, I added an option to use the following flow (default remains the top flow).

1. Build query
2. Fetch 50 rows
3. Return rows immediately
4. Count results later in a separate request

To the ORMAdapter, the following properties can be added:

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `lazy_total_count` | bool | `false` | adds lazy loading to the total count |
| `lazy_filtered_count` | bool | `false` | adds lazy loading to the filtered count |

This is controller code is used in my test project:

```
    #[Route('/', name: 'app_index')]
    public function index(Request $request, DataTableFactory $factory): Response
    {
        $table = $factory->create()
            ->add('email', TextColumn::class, ['field' => 'u.email'])
            ->add('iban', TextColumn::class, ['field' => 'u.iban'])
            ->add('name', TextColumn::class, ['field' => 'u.name'])
            ->createAdapter(ORMAdapter::class, [
                'entity' => User::class,
                'query' => function (QueryBuilder $qb) {
                    $qb->select('u')->from(User::class, 'u');
                },
                'lazy_total_count' => true,        // <-- This line adds lazy counting to the total count
                'lazy_filtered_count' => true,     // <-- This line adds lazy counting to the filtered count
            ]);

        $table->handleRequest($request);

        if ($table->isCallback()) {
            return $table->getResponse();
        }

        return $this->render('index/index.html.twig', ['datatable' => $table]);
    }
```

Tests and documentation have also been included