### PR TITLE
AbstractColumn: support TranslatableInterface for labels

### DIFF
--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -16,6 +16,7 @@ use Omines\DataTablesBundle\DataTable;
 use Omines\DataTablesBundle\DataTableState;
 use Omines\DataTablesBundle\Filter\AbstractFilter;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * AbstractColumn.
@@ -105,7 +106,7 @@ abstract class AbstractColumn
                 'enableRawExport' => false,
                 'exporterOptions' => [],
             ])
-            ->setAllowedTypes('label', ['null', 'string'])
+            ->setAllowedTypes('label', ['null', 'string', TranslatableInterface::class])
             ->setAllowedTypes('data', ['null', 'string', 'callable'])
             ->setAllowedTypes('field', ['null', 'string'])
             ->setAllowedTypes('propertyPath', ['null', 'string'])
@@ -139,7 +140,7 @@ abstract class AbstractColumn
         return $this->name;
     }
 
-    public function getLabel(): string
+    public function getLabel(): string|TranslatableInterface
     {
         return $this->options['label'] ?? "{$this->dataTable->getName()}.columns.{$this->getName()}";
     }

--- a/src/Exporter/DataTableExporterManager.php
+++ b/src/Exporter/DataTableExporterManager.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -123,7 +124,10 @@ class DataTableExporterManager
         $columns = [];
 
         foreach ($this->dataTable->getColumns() as $column) {
-            $columns[] = $this->translator->trans($column->getLabel(), [], $this->dataTable->getTranslationDomain());
+            $label = $column->getLabel();
+            $columns[] = $label instanceof TranslatableInterface
+                ? $label->trans($this->translator)
+                : $this->translator->trans($label, [], $this->dataTable->getTranslationDomain());
         }
 
         return $columns;

--- a/tests/Unit/ColumnTest.php
+++ b/tests/Unit/ColumnTest.php
@@ -24,6 +24,7 @@ use Omines\DataTablesBundle\Exception\MissingDependencyException;
 use Omines\DataTablesBundle\Exporter\DataTableExporterManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Translation\TranslatableMessage;
 use Twig\Environment as Twig;
 
 /**
@@ -78,6 +79,21 @@ class ColumnTest extends TestCase
         $this->assertFalse($column->isRaw());
         $this->assertSame('foobar', $column->transform(null));
         $this->assertSame('foo', $column->getDataTable()->getName());
+    }
+
+    /**
+     * Tests that a TranslatableInterface is accepted as column label.
+     */
+    public function testTextColumnWithTranslatableLabel(): void
+    {
+        $label = new TranslatableMessage('foo');
+
+        $column = new TextColumn();
+        $column->initialize('test', 1, [
+            'label' => $label,
+        ], $this->createDataTable()->setName('foo'));
+
+        $this->assertSame($label, $column->getLabel());
     }
 
     public function testBoolColumn(): void

--- a/tests/Unit/Exporter/DataTableExporterManagerTranslatableTest.php
+++ b/tests/Unit/Exporter/DataTableExporterManagerTranslatableTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exporter;
+
+use Omines\DataTablesBundle\Adapter\ArrayAdapter;
+use Omines\DataTablesBundle\Column\TextColumn;
+use Omines\DataTablesBundle\DataTable;
+use Omines\DataTablesBundle\Exporter\DataTableExporterCollection;
+use Omines\DataTablesBundle\Exporter\DataTableExporterInterface;
+use Omines\DataTablesBundle\Exporter\DataTableExporterManager;
+use PHPUnit\Framework\Assert;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Tests that the DataTableExporterManager supports TranslatableInterface labels.
+ */
+class DataTableExporterManagerTranslatableTest extends KernelTestCase
+{
+    public function testExportSupportsTranslatableColumnLabels(): void
+    {
+        $exporter = $this->createMock(DataTableExporterInterface::class);
+        $exporterCollection = $this->createStub(DataTableExporterCollection::class);
+        $exporterCollection
+            ->method('getByName')
+            ->willReturn($exporter)
+        ;
+
+        // Assert that the column names given to DataTableExporterInterface::export() are
+        // 'translated' from a TranslatableMessage to a string.
+        $exporter->expects(self::once())
+            ->method('export')
+            ->with(['invalid-translation-key'])
+        ;
+
+        $manager = new DataTableExporterManager($exporterCollection, $this->getContainer()->get(TranslatorInterface::class));
+        $table = new DataTable($this->createStub(EventDispatcherInterface::class), $manager);
+        $table
+            ->add('name', TextColumn::class, [
+                'label' => new TranslatableMessage('invalid-translation-key'),
+            ])
+            ->setAdapter(new ArrayAdapter(), [])
+        ;
+
+        $manager
+            ->setDataTable($table)
+            ->setExporterName('test')
+            ->getExport()  // This triggers the call to export()
+        ;
+    }
+}


### PR DESCRIPTION
This change allows column labels to accept TranslatableInterface types, mimicking the behavior of Symfony's core FormType.

By allowing the `t()` shortcut we get these benefits in our project:

- Better static analysis: Symfony's translation:extract command can now automatically pick up these keys.
- Improved IDE integration.

See Symfony's FormType:
https://github.com/symfony/form/blob/18707d0803cf949e375cd353772acaf237afb09e/Extension/Core/Type/FormType.php#L186